### PR TITLE
feat: 자동로그인 구현, 멤버 여부에 따른 로직, 가입 되어있는지에 따른 로직 추가

### DIFF
--- a/burstcamp/burstcamp/Coordinator/AuthCoordinator.swift
+++ b/burstcamp/burstcamp/Coordinator/AuthCoordinator.swift
@@ -10,7 +10,7 @@ import UIKit
 
 protocol AuthCoordinatorProtocol: Coordinator {
     func moveToTabBarFlow()
-    func moveToDomainScreen()
+    func moveToDomainScreen(userUUID: String, nickname: String)
     func moveToIDScreen(viewModel: SignUpViewModel)
     func moveToBlogScreen(viewModel: SignUpViewModel)
     // to 홈 화면
@@ -32,8 +32,8 @@ final class AuthCoordinator: AuthCoordinatorProtocol {
         logInViewController.coordinatorPublisher
             .sink { coordinatorEvent in
                 switch coordinatorEvent {
-                case .moveToDomainScreen:
-                    self.moveToDomainScreen()
+                case .moveToDomainScreen(let userUUID, let nickname):
+                    self.moveToDomainScreen(userUUID: userUUID, nickname: nickname)
                 case .moveToTabBarScreen:
                     self.moveToTabBarFlow()
                 case .moveToIDScreen, .moveToBlogScreen:
@@ -49,12 +49,15 @@ final class AuthCoordinator: AuthCoordinatorProtocol {
         finish()
     }
 
-    func moveToDomainScreen() {
-        let sighUpDomainViewController = SignUpDomainViewController(viewModel: SignUpViewModel())
+    func moveToDomainScreen(userUUID: String, nickname: String) {
+        let sighUpDomainViewController = SignUpDomainViewController(viewModel: SignUpViewModel(userUUID: userUUID, nickname: nickname))
         sighUpDomainViewController.coordinatorPublisher
             .sink { coordinatorEvent, viewModel in
-                if coordinatorEvent == .moveToIDScreen {
+                switch coordinatorEvent {
+                case .moveToIDScreen:
                     self.moveToIDScreen(viewModel: viewModel)
+                default:
+                    return
                 }
             }
             .store(in: &cancelBag)
@@ -65,8 +68,11 @@ final class AuthCoordinator: AuthCoordinatorProtocol {
         let signUpCamperIDViewController = SignUpCamperIDViewController(viewModel: viewModel)
         signUpCamperIDViewController.coordinatorPublisher
             .sink { coordinatorEvent, viewModel in
-                if coordinatorEvent == .moveToBlogScreen {
+                switch coordinatorEvent {
+                case .moveToBlogScreen:
                     self.moveToBlogScreen(viewModel: viewModel)
+                default:
+                    return
                 }
             }
             .store(in: &cancelBag)

--- a/burstcamp/burstcamp/Coordinator/AuthCoordinatorEvent.swift
+++ b/burstcamp/burstcamp/Coordinator/AuthCoordinatorEvent.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 enum AuthCoordinatorEvent {
-    case moveToDomainScreen
+    case moveToDomainScreen(String, String)
     case moveToIDScreen
     case moveToBlogScreen
     case moveToTabBarScreen

--- a/burstcamp/burstcamp/Scene/Auth/LogIn/LoginViewController.swift
+++ b/burstcamp/burstcamp/Scene/Auth/LogIn/LoginViewController.swift
@@ -51,8 +51,8 @@ final class LogInViewController: UIViewController {
         LogInManager.shared.logInPublisher
             .sink { logInEvent in
                 switch logInEvent {
-                case .moveToDomainScreen:
-                    self.coordinatorPublisher.send(.moveToDomainScreen)
+                case .moveToDomainScreen(let userUUID, let nickname):
+                    self.coordinatorPublisher.send(.moveToDomainScreen(userUUID, nickname))
                 case .moveToTabBarScreen:
                     self.coordinatorPublisher.send(.moveToTabBarScreen)
                 case .moveToBlogScreen, .moveToIDScreen:

--- a/burstcamp/burstcamp/Scene/Auth/SignUp/Blog/SignUpBlogViewController.swift
+++ b/burstcamp/burstcamp/Scene/Auth/SignUp/Blog/SignUpBlogViewController.swift
@@ -15,6 +15,7 @@ final class SignUpBlogViewController: UIViewController {
         return view
     }
 
+    private var cancelBag = Set<AnyCancellable>()
     var coordinatorPublisher = PassthroughSubject<AppCoordinatorEvent, Never>()
     private let viewModel: SignUpViewModel
 
@@ -95,6 +96,25 @@ final class SignUpBlogViewController: UIViewController {
 
         // TODO: 블로그 주소 검증
 
-        coordinatorPublisher.send(.moveToTabBarFlow)
+        FireStoreService.save(
+            user: User(
+                userUUID: viewModel.userUUID,
+                nickname: viewModel.nickname,
+                profileImageURL: "",
+                domain: viewModel.domain,
+                camperID: viewModel.camperID,
+                blogUUID: "",
+                signupDate: "", // TODO: 노션DB에는 Date로, User모델에는 String으로. 확인 필요
+                scrapFeedUUIDs: [],
+                isPushOn: false
+            )
+        )
+        .receive(on: DispatchQueue.main)
+        .sink { result in
+            print(result)
+        } receiveValue: { data in
+            print(data)
+            self.coordinatorPublisher.send(.moveToTabBarFlow)
+        }.store(in: &cancelBag)
     }
 }

--- a/burstcamp/burstcamp/Scene/Auth/SignUp/Blog/SignUpBlogViewController.swift
+++ b/burstcamp/burstcamp/Scene/Auth/SignUp/Blog/SignUpBlogViewController.swift
@@ -100,7 +100,7 @@ final class SignUpBlogViewController: UIViewController {
             user: User(
                 userUUID: viewModel.userUUID,
                 nickname: viewModel.nickname,
-                profileImageURL: "",
+                profileImageURL: "https://github.com/\(viewModel.nickname).png",
                 domain: viewModel.domain,
                 camperID: viewModel.camperID,
                 blogUUID: "",

--- a/burstcamp/burstcamp/Scene/Auth/SignUp/SignUpViewModel.swift
+++ b/burstcamp/burstcamp/Scene/Auth/SignUp/SignUpViewModel.swift
@@ -12,4 +12,11 @@ final class SignUpViewModel {
     @Published var domain: Domain = .iOS
     var camperID: String = ""
     var blogAddress: String = ""
+    let userUUID: String
+    let nickname: String
+
+    init(userUUID: String, nickname: String) {
+        self.userUUID = userUUID
+        self.nickname = nickname
+    }
 }

--- a/burstcamp/burstcamp/Service/LogInManager.swift
+++ b/burstcamp/burstcamp/Service/LogInManager.swift
@@ -11,15 +11,19 @@ import UIKit
 import FirebaseAuth
 
 final class LogInManager {
-
+    
     static let shared = LogInManager()
-
+    
     private init () {}
-
+    
     private var cancelBag = Set<AnyCancellable>()
-
+    
     var logInPublisher = PassthroughSubject<AuthCoordinatorEvent, Never>()
-
+    
+    var userUUID: String {
+        return Auth.auth().currentUser?.uid ?? ""
+    }
+    
     private var githubAPIKey: Github? {
         guard let serviceInfoURL = Bundle.main.url(
             forResource: "Service-Info",
@@ -30,38 +34,35 @@ final class LogInManager {
         else { return nil }
         return apiKey.github
     }
-
+    
     func isLoggedIn() -> Bool {
         guard Auth.auth().currentUser != nil else { return false }
         return true
     }
-
+    
     func openGithubLoginView() {
         let urlString = "https://github.com/login/oauth/authorize"
-
+        
         guard var urlComponent = URLComponents(string: urlString),
               let clientID = githubAPIKey?.clientID
         else {
             return
         }
-
+        
         urlComponent.queryItems = [
             URLQueryItem(name: "client_id", value: clientID),
             URLQueryItem(name: "scope", value: "admin:org")
         ]
-
+        
         guard let url = urlComponent.url else { return }
-
+        
         UIApplication.shared.open(url)
     }
-
+    
     func logIn(code: String) {
         var token: String = ""
         var nickname: String = ""
-        var userUUID: String {
-            return Auth.auth().currentUser?.uid ?? ""
-        }
-
+        
         requestGithubAccessToken(code: code)
             .map { $0.accessToken }
             .flatMap { accessToken -> AnyPublisher<GithubUser, NetworkError> in
@@ -74,7 +75,7 @@ final class LogInManager {
                 return self.getOrganizationMembership(nickname: nickname, token: token)
             }
             .flatMap { _ -> AnyPublisher<User, NetworkError> in
-                return FireStoreService.fetchUser(by: userUUID)
+                return FireStoreService.fetchUser(by: self.userUUID)
             }
             .receive(on: DispatchQueue.main)
             .sink { result in
@@ -82,34 +83,39 @@ final class LogInManager {
                 case .finished:
                     print("finished")
                 case .failure(let error):
-
-                    // TODO: switch -> 함수 분리 필요
-                    switch error {
-                    case .responseDecoingError:
-                        /// 멤버 O, 회원가입 X
-                        self.logInPublisher.send(.moveToDomainScreen(userUUID, nickname))
-                    default:
-                        /// 멤버 X
-                        // TODO: alert
-                        print("default")
-                    }
+                    self.switchError(error: error, nickname: nickname)
                 }
-            } receiveValue: { [weak self] user in
-
-                /// 멤버 O, 이미 회원가입
-                let credential = GitHubAuthProvider.credential(withToken: token)
-
-                Auth.auth().signIn(with: credential) { result, error in
-                    guard result != nil,
-                        error == nil
-                    else {
-                        return
-                    }
-
-                    self?.logInPublisher.send(.moveToTabBarScreen)
-                }
+            } receiveValue: { user in
+                self.signInToFirebase(user: user, token: token)
             }
             .store(in: &cancelBag)
+    }
+    
+    func switchError(error: NetworkError, nickname: String) {
+        // TODO: switch -> 함수 분리 필요
+        switch error {
+        case .responseDecoingError:
+            /// 멤버 O, 회원가입 X
+            self.logInPublisher.send(.moveToDomainScreen(userUUID, nickname))
+        default:
+            /// 멤버 X
+            // TODO: alert
+            print("default")
+        }
+    }
+    
+    func signInToFirebase(user: User, token: String) {
+        let credential = GitHubAuthProvider.credential(withToken: token)
+        
+        Auth.auth().signIn(with: credential) { result, error in
+            guard result != nil,
+                  error == nil
+            else {
+                return
+            }
+            
+            self.logInPublisher.send(.moveToTabBarScreen)
+        }
     }
 
     func requestGithubAccessToken(code: String) -> AnyPublisher<GithubToken, NetworkError> {


### PR DESCRIPTION
## 관련 이슈
<!--
이슈 번호 #000 작성  
ex) close #1 
--> 
- close #7 

## 내용
<!--
로직 설명  
필요시 스크린샷 첨부
--> 
- 기관 인증 후 FirebaseStore의 fetchUser 함수로 회원가입 여부 판단
- 회원가입 필요하면 userUUID와 nickname을 파라미터로 넣고 Domain선택 창으로 이동
- 회원가입이 되어있으면 TabBar로 이동
- Need: 에러처리를 더 명확히 할 필요가 있음

## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
