### PR TITLE
데이터베이스끼리의 연동을 위한 데이터수집 로직 개선

### DIFF
--- a/Firebase-Functions/functions/model.js
+++ b/Firebase-Functions/functions/model.js
@@ -1,0 +1,21 @@
+/*
+{
+  status: String
+  feed: {
+    url: 블로그 rss 주소
+    title: 블로그 이름
+    link: 블로그 주소
+    author:
+    description: 블로그 소개
+    image:
+  }
+  items: [{
+    title: 글 제목
+    pubDate: 글 작성 시간
+    link: 글 주소
+    author: 작성자 이름
+    thumbnail: 썸네일 주소
+    description: 글
+  }]
+}
+*/

--- a/Firebase-Functions/functions/package-lock.json
+++ b/Firebase-Functions/functions/package-lock.json
@@ -7,6 +7,7 @@
       "name": "functions",
       "dependencies": {
         "@mozilla/readability": "^0.4.2",
+        "crypto-js": "^4.1.1",
         "firebase-admin": "^11.3.0",
         "firebase-functions": "^4.1.0",
         "jsdom": "^20.0.3",
@@ -940,6 +941,11 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
+      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
     },
     "node_modules/cssom": {
       "version": "0.5.0",
@@ -4905,6 +4911,11 @@
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
       }
+    },
+    "crypto-js": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
+      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
     },
     "cssom": {
       "version": "0.5.0",

--- a/Firebase-Functions/functions/package.json
+++ b/Firebase-Functions/functions/package.json
@@ -16,6 +16,7 @@
   "main": "index.js",
   "dependencies": {
     "@mozilla/readability": "^0.4.2",
+    "crypto-js": "^4.1.1",
     "firebase-admin": "^11.3.0",
     "firebase-functions": "^4.1.0",
     "jsdom": "^20.0.3",

--- a/Firebase-Functions/functions/service/feedAPI.js
+++ b/Firebase-Functions/functions/service/feedAPI.js
@@ -9,7 +9,7 @@ import { convertURL } from '../util.js';
  * @returns 
  */
 export async function fetchParsedRSSList(urls) {
-  return await Promise.all(urls.map(async (url) => await fetchParsedRSS(url)));
+  return await Promise.all(urls.map(async (url) => await fetchParsedRSS(url)))
 }
 
 /**
@@ -18,7 +18,7 @@ export async function fetchParsedRSSList(urls) {
  * @returns 
  */
 export async function fetchParsedRSS(rssURL) {
-  const urlComponent = encodeURIComponent(rssURL);
+  const urlComponent = encodeURIComponent(rssURL)
 
   const requestURL = `https://api.rss2json.com/v1/api.json?rss_url=${urlComponent}`
   const options = {
@@ -35,7 +35,7 @@ export async function fetchParsedRSS(rssURL) {
 }
 
 export async function getBlogTitle(blogURL) {
-  const rssURL = await convertURL(blogURL)
+  const rssURL = convertURL(blogURL)
 	const rss = await fetchParsedRSS(rssURL)
   return rss.feed.title
 }
@@ -75,8 +75,8 @@ function makeReadable(dom) {
 function makeCompatibleWithMobile(dom) {
   const codeTags = dom.querySelectorAll('code')
   codeTags.forEach(code => {
-    code.innerHTML = code.innerHTML.replace(/\n/g, "<br />");
-    code.innerHTML = code.innerHTML.replace(/    /g, "\&emsp\;");
+    code.innerHTML = code.innerHTML.replace(/\n/g, "<br />")
+    code.innerHTML = code.innerHTML.replace(/    /g, "\&emsp\;")
   })
   return dom
 }

--- a/Firebase-Functions/functions/service/firestoreManager.js
+++ b/Firebase-Functions/functions/service/firestoreManager.js
@@ -44,7 +44,8 @@ async function updateFeedDBFromSingleBlog(parsedRSS) {
 async function createFeedDataIfNeeded(docRef, blogUUID, feed) {
 	const content = await fetchContent(feed.link)
 	docRef.set({
-		// writerUUID: writerUUID,
+		// TODO: User db에서 UUID를 찾아 대입해주기
+		writerUUID: "test",
 		blogUUID: blogUUID,
 		title: feed.title,
 		url: feed.link,

--- a/Firebase-Functions/functions/service/firestoreManager.js
+++ b/Firebase-Functions/functions/service/firestoreManager.js
@@ -19,7 +19,6 @@ export async function updateFeedDB() {
  * @param {JSON} parsedRSS 
  */
 async function updateFeedDBFromSingleBlog(parsedRSS) {
-	const blogUUID = parsedRSS.feed.link.hashCode();
 	await parsedRSS.items.forEach(async (item) => {
 		const feedUUID = item.link.hashCode()
 		const docRef = db.collection('feed').doc(feedUUID);
@@ -29,7 +28,7 @@ async function updateFeedDBFromSingleBlog(parsedRSS) {
 					logger.log(item.link, 'is already exist');
 					return;
 				}
-				createFeedDataIfNeeded(docRef, blogUUID, item);
+				createFeedDataIfNeeded(docRef, feedUUID, item);
 				logger.log(item.link, 'is created');
 			});
 	});
@@ -38,15 +37,15 @@ async function updateFeedDBFromSingleBlog(parsedRSS) {
 /**
  * DB에 한 포스트에 대한 정보를 저장한다.
  * @param {FirebaseFirestore.DocumentReference<FirebaseFirestore.DocumentData>} docRef feedData가 담길 Firestore의 doc 레퍼런스
- * @param {string} blogUUID blogURL을 hashing한 값
+ * @param {string} feedUUID feedURL을 hashing한 값
  * @param {JSON} feed RSS를 JSON으로 파싱한 정보
  */
-async function createFeedDataIfNeeded(docRef, blogUUID, feed) {
+async function createFeedDataIfNeeded(docRef, feedUUID, feed) {
 	const content = await fetchContent(feed.link)
 	docRef.set({
 		// TODO: User db에서 UUID를 찾아 대입해주기
+		feedUUID: feedUUID,
 		writerUUID: "test",
-		blogUUID: blogUUID,
 		title: feed.title,
 		url: feed.link,
 		thumbnail: feed.thumbnail,

--- a/Firebase-Functions/functions/service/firestoreManager.js
+++ b/Firebase-Functions/functions/service/firestoreManager.js
@@ -1,17 +1,23 @@
 import { initializeApp, getApps } from 'firebase-admin/app';
-import { getFirestore, Timestamp } from 'firebase-admin/firestore';
+import { getFirestore, QuerySnapshot, Timestamp } from 'firebase-admin/firestore';
 import { fetchContent, fetchParsedRSSList } from './feedAPI.js';
 import { logger } from 'firebase-functions';
-import '../util.js';
+import { convertURL } from '../util.js';
 
 if ( !getApps().length ) initializeApp()
-const db = getFirestore();
+const db = getFirestore()
+const userRef = db.collection('user')
+const feedRef = db.collection('feed')
 
 export async function updateFeedDB() {
-	const blogSnapshot = await db.collection('blog').get();
-	const rssURLList = blogSnapshot.docs.map(doc => doc.data()['rssURL']);
-	const parsedRSSList = await fetchParsedRSSList(rssURLList);
-	parsedRSSList.forEach(parsedRSS => updateFeedDBFromSingleBlog(parsedRSS));
+	const userSnapshot = await userRef.get()
+	const rssURLList = userSnapshot.docs.map(doc => {
+		const blogURL = doc.data()['blogURL']
+		const rssURL = convertURL(blogURL)
+		return rssURL
+	})
+	const parsedRSSList = await fetchParsedRSSList(rssURLList)
+	parsedRSSList.forEach(parsedRSS => updateFeedDBFromSingleBlog(parsedRSS))
 }
 
 /**
@@ -19,38 +25,58 @@ export async function updateFeedDB() {
  * @param {JSON} parsedRSS 
  */
 async function updateFeedDBFromSingleBlog(parsedRSS) {
+	const blogURL = parsedRSS.feed.link
+	const writerUUID = await getFeedWriterUUID(blogURL)
 	await parsedRSS.items.forEach(async (item) => {
 		const feedUUID = item.link.hashCode()
-		const docRef = db.collection('feed').doc(feedUUID);
+		const docRef = feedRef.doc(feedUUID);
 		await docRef.get()
 			.then(doc => {
 				if (doc.exists) {
-					logger.log(item.link, 'is already exist');
-					return;
+					logger.log(item.link, 'is already exist')
+					return
 				}
-				createFeedDataIfNeeded(docRef, feedUUID, item);
-				logger.log(item.link, 'is created');
-			});
-	});
+				createFeedDataIfNeeded(docRef, writerUUID, feedUUID, item)
+				logger.log(item.link, 'is created')
+			})
+	})
 }
 
 /**
  * DB에 한 포스트에 대한 정보를 저장한다.
  * @param {FirebaseFirestore.DocumentReference<FirebaseFirestore.DocumentData>} docRef feedData가 담길 Firestore의 doc 레퍼런스
+ * @param {String} writerUUID 작성자의 UUID 값
  * @param {string} feedUUID feedURL을 hashing한 값
  * @param {JSON} feed RSS를 JSON으로 파싱한 정보
  */
-async function createFeedDataIfNeeded(docRef, feedUUID, feed) {
+async function createFeedDataIfNeeded(docRef, writerUUID, feedUUID, feed) {
 	const content = await fetchContent(feed.link)
 	docRef.set({
 		// TODO: User db에서 UUID를 찾아 대입해주기
 		feedUUID: feedUUID,
-		writerUUID: "test",
+		writerUUID: writerUUID,
 		title: feed.title,
 		url: feed.link,
 		thumbnail: feed.thumbnail,
 		content: content,
 		pubDate: Timestamp.fromDate(new Date(feed.pubDate)),
 		regDate: Timestamp.now(),
-	});
+	})
+}
+
+/**
+ * 유저의 blogURL을 통해 db에서 유저를 찾고, 해당 유저의 UUID를 리턴한다.
+ * @param {String} blogURL 유저의 블로그 URL이다. 끝에 '/'이 붙어서 넘어온다.
+ * @returns 일치하는 유저의 UUID
+ */
+export async function getFeedWriterUUID(blogURL) {
+	// https://stackoverflow.com/questions/46568142/google-firestore-query-on-substring-of-a-property-value-text-search/52715590#52715590
+	return userRef
+		.where('blogURL', '>=', blogURL.slice(0, -1))
+		.where('blogURL', '<=', blogURL)
+		.limit(1)
+		.get()
+		.then((querySnapshot) => {
+			return querySnapshot.docs.at(0).id
+		})
 }

--- a/Firebase-Functions/functions/util.js
+++ b/Firebase-Functions/functions/util.js
@@ -1,19 +1,19 @@
-import { MD5 } from 'crypto-js'
+import MD5 from 'crypto-js/md5.js'
 
 /// https://stackoverflow.com/a/52171480/19782341
 String.prototype.hashCode = function() {
-	const a = MD5(this).toString()
+	return MD5(this).toString()
 }
 
 /**
- * @param {string} blogLink 블로그 주소 
+ * @param {string} blogURL 블로그 주소 
  * @returns {string} 블로그 RSS주소 
  */
-export async function convertURL(blogLink) {
-	if (blogLink.includes('tistory')) {
-		return `${blogLink}/rss`
-	} else if (blogLink.includes('velog')) {
-		const nicknameCandidate = blogLink.match(/@[\w-]+/g)
+export function convertURL(blogURL) {
+	if (blogURL.includes('tistory')) {
+		return `${blogURL}/rss`
+	} else if (blogURL.includes('velog')) {
+		const nicknameCandidate = blogURL.match(/@[\w-]+/g)
 		const nickname = nicknameCandidate[nicknameCandidate.length - 1]
 		return `v2.velog.io/rss/${nickname}`
 	}

--- a/Firebase-Functions/functions/util.js
+++ b/Firebase-Functions/functions/util.js
@@ -1,17 +1,8 @@
+import { MD5 } from 'crypto-js'
+
 /// https://stackoverflow.com/a/52171480/19782341
-String.prototype.hashCode = function (seed = 0) {
-	let h1 = 0xdeadbeef ^ seed,
-		h2 = 0x41c6ce57 ^ seed;
-	for (let i = 0, ch; i < this.length; i++) {
-		ch = this.charCodeAt(i);
-		h1 = Math.imul(h1 ^ ch, 2654435761);
-		h2 = Math.imul(h2 ^ ch, 1597334677);
-	}
-
-	h1 = Math.imul(h1 ^ (h1 >>> 16), 2246822507) ^ Math.imul(h2 ^ (h2 >>> 13), 3266489909);
-	h2 = Math.imul(h2 ^ (h2 >>> 16), 2246822507) ^ Math.imul(h1 ^ (h1 >>> 13), 3266489909);
-
-	return (4294967296 * (2097151 & h2) + (h1 >>> 0)).toString();
+String.prototype.hashCode = function() {
+	const a = MD5(this).toString()
 }
 
 /**
@@ -20,10 +11,10 @@ String.prototype.hashCode = function (seed = 0) {
  */
 export async function convertURL(blogLink) {
 	if (blogLink.includes('tistory')) {
-		return `${blogLink}/rss`;
+		return `${blogLink}/rss`
 	} else if (blogLink.includes('velog')) {
-		const nicknameCandidate = blogLink.match(/@[\w-]+/g);
-		const nickname = nicknameCandidate[nicknameCandidate.length - 1];
-		return `v2.velog.io/rss/${nickname}`;
+		const nicknameCandidate = blogLink.match(/@[\w-]+/g)
+		const nickname = nicknameCandidate[nicknameCandidate.length - 1]
+		return `v2.velog.io/rss/${nickname}`
 	}
 }

--- a/burstcamp/burstcamp/Model/Feed/Feed.swift
+++ b/burstcamp/burstcamp/Model/Feed/Feed.swift
@@ -10,7 +10,7 @@ import Foundation
 struct Feed {
     let feedUUID: String
     let writer: FeedWriter
-    let feedTitle: String
+    let title: String
     let pubDate: Date
     let url: String
     let thumbnailURL: String
@@ -20,7 +20,7 @@ struct Feed {
     init(feedDTO: FeedDTO, feedWriter: FeedWriter) {
         self.feedUUID = feedDTO.feedUUID
         self.writer = feedWriter
-        self.feedTitle = feedDTO.feedTitle
+        self.title = feedDTO.title
         self.pubDate = feedDTO.pubDate
         self.url = feedDTO.url
         self.thumbnailURL = feedDTO.thumbnailURL

--- a/burstcamp/burstcamp/Model/Feed/FeedDTO.swift
+++ b/burstcamp/burstcamp/Model/Feed/FeedDTO.swift
@@ -12,7 +12,7 @@ import Firebase
 struct FeedDTO {
     let feedUUID: String
     let writerUUID: String
-    let feedTitle: String
+    let title: String
     let pubDate: Date
     let url: String
     let thumbnailURL: String
@@ -21,7 +21,7 @@ struct FeedDTO {
     init(data: [String: Any]) {
         let feedUUID = data["feedUUID"] as? String ?? ""
         let writerUUID = data["writerUUID"] as? String ?? ""
-        let feedTitle = data["feedTitle"] as? String ?? ""
+        let title = data["title"] as? String ?? ""
         let timeStampDate = data["pubDate"] as? Timestamp ?? Timestamp()
         let pubDate = timeStampDate.dateValue()
         let url = data["url"] as? String ?? ""
@@ -30,7 +30,7 @@ struct FeedDTO {
 
         self.feedUUID = feedUUID
         self.writerUUID = writerUUID
-        self.feedTitle = feedTitle
+        self.title = title
         self.pubDate = pubDate
         self.url = url
         self.thumbnailURL = thumbnailURL

--- a/burstcamp/burstcamp/Scene/Common/View/NormalFeedCell/Main/NormalFeedCellMain.swift
+++ b/burstcamp/burstcamp/Scene/Common/View/NormalFeedCell/Main/NormalFeedCellMain.swift
@@ -60,7 +60,7 @@ class NormalFeedCellMain: UIView {
 extension NormalFeedCellMain {
     func updateView(feed: Feed) {
         DispatchQueue.main.async {
-            self.titleLabel.text = feed.feedTitle
+            self.titleLabel.text = feed.title
         }
         self.thumbnailImageView.setImage(urlString: feed.thumbnailURL)
     }

--- a/burstcamp/burstcamp/Scene/Tab/Detail/View/FeedDetailView.swift
+++ b/burstcamp/burstcamp/Scene/Tab/Detail/View/FeedDetailView.swift
@@ -91,7 +91,7 @@ extension FeedDetailView {
 
     func configure(with feed: Feed) {
         userInfoStackView.updateView(feedWriter: feed.writer)
-        titleLabel.text = feed.feedTitle
+        titleLabel.text = feed.title
         blogTitleLabel.text = feed.writer.blogTitle
         pubDateLabel.text = feed.pubDate.monthDateFormatString
         contentView.loadFormattedHTMLString(feed.content)

--- a/burstcamp/burstcamp/Scene/Tab/Detail/ViewModel/FeedDetailViewModel.swift
+++ b/burstcamp/burstcamp/Scene/Tab/Detail/ViewModel/FeedDetailViewModel.swift
@@ -122,12 +122,10 @@ final class FeedDetailViewModel {
     }
 
     private func requestDeleteFeedScrapUser(uuid: String) async throws {
+        let path = ["feed", uuid, "scrapUserUUIDs", "userUUID"].joined(separator: "/")
         try await withCheckedThrowingContinuation { continuation in
             Firestore.firestore()
-                .collection("feed")
-                .document(uuid)
-                .collection("scrapUserUUIDs")
-                .document("userUUID")
+                .document(path)
                 .delete { error in
                     if let error = error {
                         continuation.resume(throwing: error)
@@ -139,12 +137,10 @@ final class FeedDetailViewModel {
     }
 
     private func requestAppendFeedScrapUser(uuid: String) async throws {
+        let path = ["feed", uuid, "scrapUserUUIDs", "userUUID"].joined(separator: "/")
         try await withCheckedThrowingContinuation { continuation in
             Firestore.firestore()
-                .collection("feed")
-                .document(uuid)
-                .collection("scrapUserUUIDs")
-                .document("userUUID") // TODO: userUUID 삽입
+                .document(path)
                 .setData([
                     "userUUID": "userUUID",
                     "scrapDate": Timestamp(date: Date())

--- a/burstcamp/burstcamp/Scene/Tab/Detail/ViewModel/FeedDetailViewModel.swift
+++ b/burstcamp/burstcamp/Scene/Tab/Detail/ViewModel/FeedDetailViewModel.swift
@@ -178,7 +178,7 @@ final class FeedDetailViewModel {
     private func requestGetFeedWriter(uuid: String) async throws -> [String: Any] {
         try await withCheckedThrowingContinuation { continuation in
             Firestore.firestore()
-                .collection("User")
+                .collection("user")
                 .document(uuid)
                 .getDocument { documentSnapShot, error in
                     if let error = error {

--- a/burstcamp/burstcamp/Scene/Tab/Home/ViewController/HomeViewController.swift
+++ b/burstcamp/burstcamp/Scene/Tab/Home/ViewController/HomeViewController.swift
@@ -173,8 +173,8 @@ extension HomeViewController: UICollectionViewDelegate, UICollectionViewDataSour
 
     // FeedDetail Test용
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        let viewModel = FeedDetailViewModel(feedUUID: "3818882029078639")
-        //        let viewModel = FeedDetailViewModel(feed: Feed(camperName: "", camperDomain: "", camperNumber: 7, camperID: "", blogUUID: "", title: "", pubDate: Date(), url: "https://luen.tistory.com/204", thumbnail: "", content: ""))
+        let feed = viewModel.normalFeedData[indexPath.row]
+        let viewModel = FeedDetailViewModel(feed: feed)
         let viewController = FeedDetailViewController(viewModel: viewModel)
         navigationController?.pushViewController(viewController, animated: true)
     }


### PR DESCRIPTION
## 관련 이슈
<!--
이슈 번호 #000 작성  
ex) close #1 
--> 

## 내용
<!--
로직 설명  
필요시 스크린샷 첨부
--> 
파베 작업 했습니다.
<img width="500" alt="2022-12-02_21-19-05" src="https://user-images.githubusercontent.com/46219689/205291527-c2a27659-d592-4d8b-b1a3-beee92df52b3.png">
이제 feed를 파싱할 때, writerUUID도 함께 저장합니다.
이제 파싱된 정보를 클라이언트에서 그대로 사용해도 오류가 안납니다.
암호화엔 취약하지만 범용적인 hash함수인 `MD5`를 사용했습니다.

## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
