### PR TITLE
[모아보기] 유저 ScrapFeedUUIDs 기반으로 파이어베이스 호출

### DIFF
--- a/burstcamp/burstcamp.xcodeproj/project.pbxproj
+++ b/burstcamp/burstcamp.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		14927E202929CCA0001F2E97 /* RecommendFeedHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14927E1F2929CCA0001F2E97 /* RecommendFeedHeader.swift */; };
 		14A93D402936EFF900790034 /* FeedDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14A93D3F2936EFF900790034 /* FeedDTO.swift */; };
 		14A93D422936F00F00790034 /* FeedWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14A93D412936F00F00790034 /* FeedWriter.swift */; };
+		14F94BE62939E16D0058A79A /* UICollectionView+emptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F94BE52939E16D0058A79A /* UICollectionView+emptyView.swift */; };
 		3B061FD82928CC5600BFA71D /* SignUpDomainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B061FD72928CC5600BFA71D /* SignUpDomainViewController.swift */; };
 		3B061FDA2928CF7E00BFA71D /* SighUpDomainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B061FD92928CF7E00BFA71D /* SighUpDomainView.swift */; };
 		3B061FDD2928E8E300BFA71D /* SignUpCamperIDViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B061FDC2928E8E300BFA71D /* SignUpCamperIDViewController.swift */; };
@@ -182,6 +183,7 @@
 		14927E1F2929CCA0001F2E97 /* RecommendFeedHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecommendFeedHeader.swift; sourceTree = "<group>"; };
 		14A93D3F2936EFF900790034 /* FeedDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedDTO.swift; sourceTree = "<group>"; };
 		14A93D412936F00F00790034 /* FeedWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedWriter.swift; sourceTree = "<group>"; };
+		14F94BE52939E16D0058A79A /* UICollectionView+emptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionView+emptyView.swift"; sourceTree = "<group>"; };
 		3B061FD72928CC5600BFA71D /* SignUpDomainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpDomainViewController.swift; sourceTree = "<group>"; };
 		3B061FD92928CF7E00BFA71D /* SighUpDomainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SighUpDomainView.swift; sourceTree = "<group>"; };
 		3B061FDC2928E8E300BFA71D /* SignUpCamperIDViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpCamperIDViewController.swift; sourceTree = "<group>"; };
@@ -331,6 +333,7 @@
 				D89AE4E52933AEF900446AB3 /* UIImageView+Cache.swift */,
 				D84C8131292F0A1E00C984E8 /* UIViewController+.swift */,
 				1418960129377593005A42D4 /* UIScrollView+.swift */,
+				14F94BE52939E16D0058A79A /* UICollectionView+emptyView.swift */,
 			);
 			path = UI;
 			sourceTree = "<group>";
@@ -1073,6 +1076,7 @@
 				D84452E7292C9A54008E811B /* TabBarCoordinatorEvent.swift in Sources */,
 				B50A27E429279F5D00DF3E1F /* APIKey.swift in Sources */,
 				B50A27ED29279F5D00DF3E1F /* NormalFeedCell.swift in Sources */,
+				14F94BE62939E16D0058A79A /* UICollectionView+emptyView.swift in Sources */,
 				D8C3AA2929305C05008EE77C /* HTTPHeader.swift in Sources */,
 				141344D6292F801100187B86 /* Date+FormatString.swift in Sources */,
 				D89AE4FD2935F5AE00446AB3 /* FireFunctionsManager.swift in Sources */,

--- a/burstcamp/burstcamp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/burstcamp/burstcamp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,131 @@
+{
+  "pins" : [
+    {
+      "identity" : "abseil-cpp-swiftpm",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/abseil-cpp-SwiftPM.git",
+      "state" : {
+        "revision" : "583de9bd60f66b40e78d08599cc92036c2e7e4e1",
+        "version" : "0.20220203.2"
+      }
+    },
+    {
+      "identity" : "boringssl-swiftpm",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/boringssl-SwiftPM.git",
+      "state" : {
+        "revision" : "dd3eda2b05a3f459fc3073695ad1b28659066eab",
+        "version" : "0.9.1"
+      }
+    },
+    {
+      "identity" : "firebase-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/firebase-ios-sdk.git",
+      "state" : {
+        "revision" : "c24031ad9410c746c49deddc739fdf311a386fc7",
+        "version" : "10.2.0"
+      }
+    },
+    {
+      "identity" : "googleappmeasurement",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleAppMeasurement.git",
+      "state" : {
+        "revision" : "71eb6700dd53a851473c48d392f00a3ab26699a6",
+        "version" : "10.1.0"
+      }
+    },
+    {
+      "identity" : "googledatatransport",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleDataTransport.git",
+      "state" : {
+        "revision" : "5056b15c5acbb90cd214fe4d6138bdf5a740e5a8",
+        "version" : "9.2.0"
+      }
+    },
+    {
+      "identity" : "googleutilities",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleUtilities.git",
+      "state" : {
+        "revision" : "6db6edb48bdd9943426562c7f042a5492de5ba3d",
+        "version" : "7.10.0"
+      }
+    },
+    {
+      "identity" : "grpc-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/grpc/grpc-ios.git",
+      "state" : {
+        "revision" : "8440b914756e0d26d4f4d054a1c1581daedfc5b6",
+        "version" : "1.44.3-grpc"
+      }
+    },
+    {
+      "identity" : "gtm-session-fetcher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/gtm-session-fetcher.git",
+      "state" : {
+        "revision" : "efda500b6d9858d38a76dbfbfa396bd644692e4a",
+        "version" : "3.0.0"
+      }
+    },
+    {
+      "identity" : "leveldb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/leveldb.git",
+      "state" : {
+        "revision" : "0706abcc6b0bd9cedfbb015ba840e4a780b5159b",
+        "version" : "1.22.2"
+      }
+    },
+    {
+      "identity" : "nanopb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/nanopb.git",
+      "state" : {
+        "revision" : "819d0a2173aff699fb8c364b6fb906f7cdb1a692",
+        "version" : "2.30909.0"
+      }
+    },
+    {
+      "identity" : "promises",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/promises.git",
+      "state" : {
+        "revision" : "3e4e743631e86c8c70dbc6efdc7beaa6e90fd3bb",
+        "version" : "2.1.1"
+      }
+    },
+    {
+      "identity" : "snapkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SnapKit/SnapKit.git",
+      "state" : {
+        "revision" : "f222cbdf325885926566172f6f5f06af95473158",
+        "version" : "5.6.0"
+      }
+    },
+    {
+      "identity" : "swift-protobuf",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-protobuf.git",
+      "state" : {
+        "revision" : "ab3a58b7209a17d781c0d1dbb3e1ff3da306bae8",
+        "version" : "1.20.3"
+      }
+    },
+    {
+      "identity" : "then",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/devxoul/Then.git",
+      "state" : {
+        "revision" : "d41ef523faef0f911369f79c0b96815d9dbb6d7a",
+        "version" : "3.0.0"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/burstcamp/burstcamp/Scene/Tab/Home/ViewModel/HomeViewModel.swift
+++ b/burstcamp/burstcamp/Scene/Tab/Home/ViewModel/HomeViewModel.swift
@@ -106,7 +106,7 @@ final class HomeViewModel {
     ) async throws -> [Feed] {
         try await withThrowingTaskGroup(of: Feed.self, body: { taskGroup in
             var normalFeeds: [Feed] = []
-            let feedDTODictionary = try await self.fetchNormalFeeds(
+            let feedDTODictionary = try await self.fetchNormalFeedDTOs(
                 lastSnapShot: lastSnapShot,
                 isPagination: isPagination
             )

--- a/burstcamp/burstcamp/Scene/Tab/MyPage/ViewController/MyPageViewController.swift
+++ b/burstcamp/burstcamp/Scene/Tab/MyPage/ViewController/MyPageViewController.swift
@@ -8,6 +8,8 @@
 import Combine
 import UIKit
 
+import FirebaseAuth
+
 final class MyPageViewController: UIViewController {
 
     // MARK: - Properties
@@ -138,6 +140,7 @@ extension MyPageViewController {
 
     private func moveToAuthFlow() {
         // TODO: 탈퇴 로직 추가
+        try? Auth.auth().signOut()
         coordinatorPublisher.send(.moveToAuthFlow)
     }
 }

--- a/burstcamp/burstcamp/Scene/Tab/ScrapPage/ViewController/ScrapPageViewController.swift
+++ b/burstcamp/burstcamp/Scene/Tab/ScrapPage/ViewController/ScrapPageViewController.swift
@@ -78,7 +78,12 @@ extension ScrapPageViewController: UICollectionViewDelegateFlowLayout, UICollect
         _ collectionView: UICollectionView,
         numberOfItemsInSection section: Int
     ) -> Int {
-        return 10
+        if viewModel.scarpFeedData.isEmpty {
+            collectionView.configureEmptyView()
+        } else {
+            collectionView.resetEmptyView()
+        }
+        return viewModel.scarpFeedData.count
     }
 
     func collectionView(

--- a/burstcamp/burstcamp/Scene/Tab/ScrapPage/ViewModel/ScrapPageViewModel.swift
+++ b/burstcamp/burstcamp/Scene/Tab/ScrapPage/ViewModel/ScrapPageViewModel.swift
@@ -8,4 +8,6 @@
 import Foundation
 
 final class ScrapPageViewModel {
+
+    var scarpFeedData: [Feed] = []
 }

--- a/burstcamp/burstcamp/Scene/Tab/ScrapPage/ViewModel/ScrapPageViewModel.swift
+++ b/burstcamp/burstcamp/Scene/Tab/ScrapPage/ViewModel/ScrapPageViewModel.swift
@@ -5,9 +5,139 @@
 //  Created by youtak on 2022/11/21.
 //
 
+import Combine
 import Foundation
+
+import FirebaseFirestore
 
 final class ScrapPageViewModel {
 
     var scarpFeedData: [Feed] = []
+    private var willRequestFeedID: [String] = []
+    var cancelBag = Set<AnyCancellable>()
+
+    private let requestFeedNumber = 5
+    private var isFetching: Bool = false
+    private var canFetchMoreFeed: Bool = true
+
+    struct Input {
+        let viewDidLoad: AnyPublisher<Void, Never>
+        let viewRefresh: AnyPublisher<Bool, Never>
+        let pagination: AnyPublisher<Void, Never>
+    }
+
+    enum FetchResult {
+        case fetchFail(error: Error)
+        case fetchSuccess
+    }
+
+    struct Output {
+        var fetchResult = PassthroughSubject<FetchResult, Never>()
+    }
+
+    func transform(input: Input) -> Output {
+        let output = Output()
+
+        input.viewDidLoad
+            .sink { [weak self] _ in
+                self?.fetchFeed(output: output)
+            }
+            .store(in: &cancelBag)
+
+        input.viewRefresh
+            .sink { [weak self] _ in
+                self?.fetchFeed(output: output)
+            }
+            .store(in: &cancelBag)
+
+        input.pagination
+            .sink { [weak self] _ in
+                self?.paginateFeed(output: output)
+            }
+            .store(in: &cancelBag)
+
+        return output
+    }
+
+    private func getUserScarpUUID() -> [String] {
+        return [
+            "Test2", "Test4", "Test6", "Test8", "Test10",
+                "Test3", "Test5", "Test7", "Test9", "Test11", "Feed1"
+        ]
+    }
+
+    private func initScrapFeedUUID() {
+        willRequestFeedID = getUserScarpUUID()
+    }
+
+    private func fetchFeed(output: Output) {
+        initScrapFeedUUID()
+        Task { [weak self] in
+            for _ in 0..<requestFeedNumber {
+                let feedUUID = willRequestFeedID.popLast()
+                guard let feedUUID = feedUUID else { return }
+                let feed = try await requestFeed(uuid: feedUUID)
+                print(feed)
+                self?.scarpFeedData.append(feed)
+            }
+            output.fetchResult.send(.fetchSuccess)
+        }
+    }
+
+    private func fetchWriter() {
+    }
+
+    private func paginateFeed(output: Output) {
+    }
+
+    private func requestFeed(uuid: String) async throws -> Feed {
+        let feedDTO = try await requestFeedDTO(uuid: uuid)
+        let feedWriter = try await requestFeedWriter(uuid: feedDTO.writerUUID)
+        let feed = Feed(feedDTO: feedDTO, feedWriter: feedWriter)
+        return feed
+    }
+
+    private func requestFeedDTO(uuid: String) async throws -> FeedDTO {
+        try await withCheckedThrowingContinuation({ continuation in
+            Firestore.firestore()
+                .collection("Feed")
+                .document(uuid)
+                .getDocument { documentSnapShot, error in
+                    if let error = error {
+                        continuation.resume(throwing: error)
+                        return
+                    }
+                    guard let snapShot = documentSnapShot,
+                          let feedDTOData = snapShot.data()
+                    else {
+                        continuation.resume(throwing: FirebaseError.fetchUserError)
+                        return
+                    }
+                    let feedDTO = FeedDTO(data: feedDTOData)
+                    continuation.resume(returning: feedDTO)
+                }
+        })
+    }
+
+    private func requestFeedWriter(uuid: String) async throws -> FeedWriter {
+        try await withCheckedThrowingContinuation({ continuation in
+            Firestore.firestore()
+                .collection("User")
+                .document(uuid)
+                .getDocument { documentSnapShot, error in
+                    if let error = error {
+                        continuation.resume(throwing: error)
+                        return
+                    }
+                    guard let snapShot = documentSnapShot,
+                          let userData = snapShot.data()
+                    else {
+                        continuation.resume(throwing: FirebaseError.fetchUserError)
+                        return
+                    }
+                    let feedWriter = FeedWriter(data: userData)
+                    continuation.resume(returning: feedWriter)
+                }
+        })
+    }
 }

--- a/burstcamp/burstcamp/Scene/Tab/ScrapPage/ViewModel/ScrapPageViewModel.swift
+++ b/burstcamp/burstcamp/Scene/Tab/ScrapPage/ViewModel/ScrapPageViewModel.swift
@@ -18,7 +18,7 @@ final class ScrapPageViewModel {
     private var willRequestFeedID: [String] = []
     var cancelBag = Set<AnyCancellable>()
 
-    private let requestFeedNumber = 7
+    private let requestFeedCount = 7
     private var isFetching: Bool = false
     private var canFetchMoreFeed: Bool = true
 

--- a/burstcamp/burstcamp/Service/LogInManager.swift
+++ b/burstcamp/burstcamp/Service/LogInManager.swift
@@ -21,7 +21,7 @@ final class LogInManager {
     var logInPublisher = PassthroughSubject<AuthCoordinatorEvent, Never>()
 
     var userUUID: String {
-        return Auth.auth().currentUser?.uid ?? "1432"
+        return Auth.auth().currentUser?.uid ?? ""
     }
 
     private var githubAPIKey: Github? {

--- a/burstcamp/burstcamp/Service/LogInManager.swift
+++ b/burstcamp/burstcamp/Service/LogInManager.swift
@@ -21,7 +21,7 @@ final class LogInManager {
     var logInPublisher = PassthroughSubject<AuthCoordinatorEvent, Never>()
 
     var userUUID: String {
-        return Auth.auth().currentUser?.uid ?? ""
+        return Auth.auth().currentUser?.uid ?? "1432"
     }
 
     private var githubAPIKey: Github? {

--- a/burstcamp/burstcamp/Util/Extension/UI/UICollectionView+emptyView.swift
+++ b/burstcamp/burstcamp/Util/Extension/UI/UICollectionView+emptyView.swift
@@ -1,0 +1,52 @@
+//
+//  UICollectionView+emptyView.swift
+//  burstcamp
+//
+//  Created by youtak on 2022/12/02.
+//
+
+import UIKit
+
+import SnapKit
+
+extension UICollectionView {
+
+    func configureEmptyView() {
+        let emptyView = UIView().then {
+            $0.frame = CGRect(
+                x: self.center.x,
+                y: self.center.y,
+                width: self.bounds.width,
+                height: self.bounds.height
+            )
+        }
+
+        let imageView = UIImageView().then {
+            $0.image = UIImage(named: "AppIcon")
+        }
+
+        let descriptionLabel = UILabel().then {
+            $0.text = "아직 스크랩한 피드가 없어요"
+            $0.font = .regular14
+            $0.textColor = .systemGray2
+        }
+
+        emptyView.addSubViews([imageView, descriptionLabel])
+
+        imageView.snp.makeConstraints { make in
+            make.centerX.centerY.equalToSuperview()
+            make.width.height.equalTo(Constant.Image.profileMedium)
+        }
+
+        descriptionLabel.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.top.equalTo(imageView.snp.bottom)
+        }
+
+        self.backgroundView = emptyView
+    }
+
+    func resetEmptyView() {
+        self.backgroundView = nil
+    }
+}


### PR DESCRIPTION
## 관련 이슈
<!--
이슈 번호 #000 작성  
ex) close #1 
--> 
- close #75 
- close #142 

## 내용
<!--
로직 설명  
필요시 스크린샷 첨부
--> 
- 사용자가 가지고있는 scrapFeedUUIDs를 기반으로 Feed를 비동기호출합니다. 현재 user에서 에러가 발생해 목업 데이터로 대체했습니다.
- 구독한 피드가 없을 때 보여주는 empty View를 구현했습니다.
- 로직은 아래 그림 참고부탁드립니다.

<img width = 393 src = "https://user-images.githubusercontent.com/71776532/205419317-4e2fc1b4-be1f-4e19-98fc-0d61196668d4.png" />

### 동작 영상 

https://user-images.githubusercontent.com/71776532/205419373-eb8ae2df-a449-4ab7-b9e2-2beaac8661fa.mp4

## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 
- 함수 이름을 fetch로 통일했습니다. 클린코드를 위해서 request, fetch 등의 용어를 통일할 필요가 있어보입니다.
- 플래그 변수(isFetching, canFetchMoreData)를 깔끔하게 다루기 위한 방법을 고민하고 있습니다. Combine을 사용해 네트워크 처리 전 후로 설정을 해주려는데 좋은 의견있으면 부탁드리겠습니다.
- 한 화면에 피드가 5개씩 들어가는데 80% 이상일 때 페이지네이션 요청이되는 지 확인하기 위해 한 번에 요청하는 개수를 7개로 설정했습니다. 추후에 홈과 10개로 통일할 예정입니다.

![설명](https://user-images.githubusercontent.com/71776532/205419250-e95c41a3-0da0-493c-84f3-c230319053cc.jpg)


## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
