### PR TITLE
[스크랩] 스크랩 클릭시 로컬에서 Up & Down 처리

### DIFF
--- a/burstcamp/burstcamp/Scene/Common/View/NormalFeedCell/NormalFeedCell.swift
+++ b/burstcamp/burstcamp/Scene/Common/View/NormalFeedCell/NormalFeedCell.swift
@@ -97,6 +97,9 @@ final class NormalFeedCell: UICollectionViewCell {
             .assign(to: \.isEnabled, on: scrapButton)
             .store(in: &cancelBag)
     }
+
+    private func updateScrapCount(scrapCount: Int) {
+    }
 }
 
 extension NormalFeedCell {

--- a/burstcamp/burstcamp/Scene/Common/ViewModel/FeedScrapViewModel.swift
+++ b/burstcamp/burstcamp/Scene/Common/ViewModel/FeedScrapViewModel.swift
@@ -62,8 +62,11 @@ final class FeedScrapViewModel {
             .share()
 
         sharedDBUpdateResult
-            .sink { _ in
-                self.scrapToggleButtonIsEnabled.send(true)
+            .sink { [weak self] _ in
+                guard let feedUUID = self?.feedUUID else { return }
+                let state = UserManager.shared.user.scrapFeedUUIDs.contains(feedUUID)
+                self?.scrapCountUp.send(state)
+                self?.scrapToggleButtonIsEnabled.send(true)
             }
             .store(in: &cancelBag)
 
@@ -72,7 +75,6 @@ final class FeedScrapViewModel {
             .map { [weak self] _ in
                 guard let feedUUID = self?.feedUUID else { return false }
                 let state = UserManager.shared.user.scrapFeedUUIDs.contains(feedUUID)
-                self?.scrapCountUp.send(state)
                 return state
             }
             .eraseToAnyPublisher()

--- a/burstcamp/burstcamp/Scene/Common/ViewModel/FeedScrapViewModel.swift
+++ b/burstcamp/burstcamp/Scene/Common/ViewModel/FeedScrapViewModel.swift
@@ -20,6 +20,7 @@ final class FeedScrapViewModel {
 
     private let dbUpdateResult = PassthroughSubject<Bool, Never>()
     private let scrapToggleButtonIsEnabled = PassthroughSubject<Bool, Never>()
+    private let scrapCountUp = PassthroughSubject<Bool, Never>()
     private let feedUUID: String
     private let userUUID: String
 
@@ -70,7 +71,9 @@ final class FeedScrapViewModel {
             .merge(with: sharedDBUpdateResult)
             .map { [weak self] _ in
                 guard let feedUUID = self?.feedUUID else { return false }
-                return UserManager.shared.user.scrapFeedUUIDs.contains(feedUUID)
+                let state = UserManager.shared.user.scrapFeedUUIDs.contains(feedUUID)
+                self?.scrapCountUp.send(state)
+                return state
             }
             .eraseToAnyPublisher()
 
@@ -78,6 +81,10 @@ final class FeedScrapViewModel {
             scrapToggleButtonState: scrapToggleButtonState,
             scrapToggleButtonIsEnabled: scrapToggleButtonIsEnabled.eraseToAnyPublisher()
         )
+    }
+
+    var getScrapCountUp: AnyPublisher<Bool, Never> {
+        return scrapCountUp.eraseToAnyPublisher()
     }
 
     private func updateFeed(userUUID: String, feedUUID: String, scrapState: Bool) {

--- a/burstcamp/burstcamp/Scene/Tab/Home/View/FeedCellType.swift
+++ b/burstcamp/burstcamp/Scene/Tab/Home/View/FeedCellType.swift
@@ -24,6 +24,12 @@ extension FeedCellType {
         }
     }
 
+    var index: Int {
+        switch self {
+        case .recommend: return 0
+        case .normal: return 1
+        }
+    }
     static var count: Int {
         return FeedCellType.allCases.count
     }

--- a/burstcamp/burstcamp/Scene/Tab/Home/ViewController/HomeViewController.swift
+++ b/burstcamp/burstcamp/Scene/Tab/Home/ViewController/HomeViewController.swift
@@ -100,7 +100,7 @@ final class HomeViewController: UIViewController {
             .store(in: &cancelBag)
     }
 
-    func reloadCollectionView(indexPath: IndexPath) {
+    private func reloadCollectionView(indexPath: IndexPath) {
         UIView.performWithoutAnimation {
             homeView.collectionView.reloadItems(at: [indexPath])
         }
@@ -157,6 +157,7 @@ extension HomeViewController: UICollectionViewDelegate, UICollectionViewDataSour
             let index = indexPath.row
             let feed = viewModel.normalFeedData[index]
             let cellViewModel = viewModel.dequeueCellViewModel(at: index)
+
             cell.configure(with: cellViewModel)
             cell.updateFeedCell(with: feed)
 

--- a/burstcamp/burstcamp/Scene/Tab/Home/ViewController/HomeViewController.swift
+++ b/burstcamp/burstcamp/Scene/Tab/Home/ViewController/HomeViewController.swift
@@ -101,7 +101,9 @@ final class HomeViewController: UIViewController {
     }
 
     func reloadCollectionView(indexPath: IndexPath) {
-        homeView.collectionView.reloadItems(at: [indexPath])
+        UIView.performWithoutAnimation {
+            homeView.collectionView.reloadItems(at: [indexPath])
+        }
     }
 
     private func paginateFeed() {
@@ -113,7 +115,6 @@ extension HomeViewController: UICollectionViewDelegate, UICollectionViewDataSour
     func numberOfSections(in collectionView: UICollectionView) -> Int {
         return FeedCellType.count
     }
-
     func collectionView(
         _ collectionView: UICollectionView,
         numberOfItemsInSection section: Int

--- a/burstcamp/burstcamp/Scene/Tab/Home/ViewController/HomeViewController.swift
+++ b/burstcamp/burstcamp/Scene/Tab/Home/ViewController/HomeViewController.swift
@@ -91,6 +91,17 @@ final class HomeViewController: UIViewController {
                 }
             }
             .store(in: &cancelBag)
+
+        output.cellUpdate
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] indexPath in
+                self?.reloadCollectionView(indexPath: indexPath)
+            }
+            .store(in: &cancelBag)
+    }
+
+    func reloadCollectionView(indexPath: IndexPath) {
+        homeView.collectionView.reloadItems(at: [indexPath])
     }
 
     private func paginateFeed() {
@@ -144,7 +155,8 @@ extension HomeViewController: UICollectionViewDelegate, UICollectionViewDataSour
             }
             let index = indexPath.row
             let feed = viewModel.normalFeedData[index]
-            cell.configure(with: viewModel.dequeueCellViewModel(at: index))
+            let cellViewModel = viewModel.dequeueCellViewModel(at: index)
+            cell.configure(with: cellViewModel)
             cell.updateFeedCell(with: feed)
 
             return cell

--- a/burstcamp/burstcamp/Scene/Tab/Home/ViewModel/HomeViewModel.swift
+++ b/burstcamp/burstcamp/Scene/Tab/Home/ViewModel/HomeViewModel.swift
@@ -273,7 +273,7 @@ final class HomeViewModel {
     }
 
     private func countFeedScrapCount(uuid: String) async throws -> Int {
-        let path = ["feed", uuid, "scrapUserUUIDs"].joined(separator: "/")
+        let path = ["feed", uuid, "scrapUsers"].joined(separator: "/")
         let countQuery = Firestore.firestore().collection(path).count
         let collectionCount = try await countQuery.getAggregation(source: .server)
         return Int(truncating: collectionCount.count)


### PR DESCRIPTION
## 관련 이슈
<!--
이슈 번호 #000 작성  
ex) close #1 
--> 
- close #178 

## 내용
<!--
로직 설명  
필요시 스크린샷 첨부
--> 
- 스크랩 버튼을 누르면 count up & down이 표시됩니다.
- 정책에 따라 로컬 변경 값만 반영합니다. 실시간 업데이트 값을 보려면 refresh해줘야 합니다.   
- 현재 로직 (피그마에 있음)
![스크린샷 2022-12-06 오후 2 00 43](https://user-images.githubusercontent.com/71776532/205820447-6a4d628a-29c2-4437-8b8c-0c7dcaab40b2.png)  

## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 
- 현재 feed데이터를 HomeViewModel이 가지고 있어서 위 그림과 같은 구조가 되었습니다. Cell의 스크랩 버튼을 누르면 CellViewModel에서 네트워크처리를 하고 HomeViewModel에서 모델을 수정해줘야 합니다. CellViewModel과 관련해 더 괜찮은 구조가 있다면 가감없이 코멘트 부탁드립니다.  

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
- 마지막 MVP!