### PR TITLE
[이미지 캐시] 정책 개선 및 사이즈 개선

### DIFF
--- a/burstcamp/burstcamp/Service/ImageCacheManager.swift
+++ b/burstcamp/burstcamp/Service/ImageCacheManager.swift
@@ -33,8 +33,8 @@ final class ImageCacheManager: NSObject, NSCacheDelegate {
     }
 
     func cache(_ cache: NSCache<AnyObject, AnyObject>, willEvictObject obj: Any) {
-        guard let image = obj as? UIImage else { return }
-        print("\(image)삭제중...\n", obj)
+//        guard let image = obj as? UIImage else { return }
+//        print("\(image)삭제중...\n", obj)
     }
 
     func image(
@@ -130,7 +130,7 @@ final class ImageCacheManager: NSObject, NSCacheDelegate {
                         throw self.makeImageCacheError(by: response.statusCode)
                     }
                 }
-                print(data)
+//                print(data)
                 return self.createThumnail(data: data)
             }
             .map { image in
@@ -182,7 +182,7 @@ final class ImageCacheManager: NSObject, NSCacheDelegate {
               let imageHeight = properties[kCGImagePropertyPixelHeight] as? UInt
         else { return UIImage() }
 
-        print(imageWidth, imageHeight)
+//        print(imageWidth, imageHeight)
         let imageMaxPixel = maxPixel(width: imageWidth, height: imageHeight)
 
         let thumnailOptions = [
@@ -200,7 +200,7 @@ final class ImageCacheManager: NSObject, NSCacheDelegate {
 
     private func maxPixel(width: UInt, height: UInt) -> Int {
         let max = Int(max(width, height))
-        print("최대픽셀", maxPixel)
+//        print("최대픽셀", maxPixel)
         switch max {
         case 0...300: return max
         case 301...600: return ImageCacheManager.thumnailMaxPixel

--- a/burstcamp/burstcamp/Util/Constant/Constant.swift
+++ b/burstcamp/burstcamp/Util/Constant/Constant.swift
@@ -56,7 +56,7 @@ enum Constant {
         static let profileMedium = 64
         static let profileLarge = 100
         static let thumbnailWidth = 100
-        static let thumbnailHeight = 100
+        static let thumbnailHeight = 75
         static let thumbnailCornerRadius = 10
     }
 

--- a/burstcamp/burstcamp/Util/Extension/UI/UIImageView+Cache.swift
+++ b/burstcamp/burstcamp/Util/Extension/UI/UIImageView+Cache.swift
@@ -10,8 +10,12 @@ import UIKit
 
 extension UIImageView {
 
-    func setImage(urlString: String, isDiskCaching: Bool = false) {
+    func setImage(urlString: String,
+                  isDiskCaching: Bool = false,
+                  defaultImage: UIImage? = UIImage(named: "burstcamper100")
+    ) {
         ImageCacheManager.shared.image(urlString: urlString, isDiskCaching: isDiskCaching)
+            .map { image in image == nil ? defaultImage : image }
             .receive(on: DispatchQueue.main)
             .assign(to: \.image, on: self)
             .store(in: &ImageCacheManager.shared.cancelBag)


### PR DESCRIPTION
## 관련 이슈
- close #186 

## 내용
https://luen.tistory.com/210

## 리뷰어가 확인할 사항

NSCache 정책은 100개 사진, 100MB 인데 삭제가 너무 빈번히 일어나서 다시 확인해봐야합니다.

print문 또 쓸거에요!

## 기타
이슈 참조
