### PR TITLE
[회원가입] indicator 하단뷰, 탈퇴시 재인증처리

### DIFF
--- a/burstcamp/burstcamp.xcodeproj/project.pbxproj
+++ b/burstcamp/burstcamp.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		3B7491E92938DCCD00A4BEA0 /* SignUpDomainViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B7491E82938DCCD00A4BEA0 /* SignUpDomainViewModel.swift */; };
 		3B7491EB2938F12600A4BEA0 /* SignUpCamperIDViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B7491EA2938F12600A4BEA0 /* SignUpCamperIDViewModel.swift */; };
 		3B74920D293DCCAC00A4BEA0 /* GithubError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B74920C293DCCAC00A4BEA0 /* GithubError.swift */; };
+		3B7492292942EDCB00A4BEA0 /* FirebaseAuthError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B7492282942EDCB00A4BEA0 /* FirebaseAuthError.swift */; };
 		B500C9EE293DBA0800EBE39E /* FeedScrapViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B500C9ED293DBA0800EBE39E /* FeedScrapViewModel.swift */; };
 		B50A27CF29279F5D00DF3E1F /* Constant.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50A278B29279F5D00DF3E1F /* Constant.swift */; };
 		B50A27DA29279F5D00DF3E1F /* ReusableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50A279729279F5D00DF3E1F /* ReusableView.swift */; };
@@ -225,6 +226,7 @@
 		3B7491E82938DCCD00A4BEA0 /* SignUpDomainViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpDomainViewModel.swift; sourceTree = "<group>"; };
 		3B7491EA2938F12600A4BEA0 /* SignUpCamperIDViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpCamperIDViewModel.swift; sourceTree = "<group>"; };
 		3B74920C293DCCAC00A4BEA0 /* GithubError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GithubError.swift; sourceTree = "<group>"; };
+		3B7492282942EDCB00A4BEA0 /* FirebaseAuthError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseAuthError.swift; sourceTree = "<group>"; };
 		B500C9ED293DBA0800EBE39E /* FeedScrapViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedScrapViewModel.swift; sourceTree = "<group>"; };
 		B50A277129279F2600DF3E1F /* burstcamp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = burstcamp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B50A278B29279F5D00DF3E1F /* Constant.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Constant.swift; sourceTree = "<group>"; };
@@ -493,6 +495,7 @@
 				D89E48B02939D9AC00744A56 /* FireStorageError.swift */,
 				3B74920C293DCCAC00A4BEA0 /* GithubError.swift */,
 				1496CF222940AEC6008F312F /* ConvertError.swift */,
+				3B7492282942EDCB00A4BEA0 /* FirebaseAuthError.swift */,
 			);
 			path = Error;
 			sourceTree = "<group>";
@@ -1217,6 +1220,7 @@
 				141344D0292F800300187B86 /* UIView+addSubViews.swift in Sources */,
 				B5E0D94C292F750D001727F5 /* FeedContentWebView.swift in Sources */,
 				B50A27E229279F5D00DF3E1F /* LogInManager.swift in Sources */,
+				3B7492292942EDCB00A4BEA0 /* FirebaseAuthError.swift in Sources */,
 				B50A27F529279F5D00DF3E1F /* AppCoordinator.swift in Sources */,
 				B50A27F929279F5D00DF3E1F /* TabBarPage.swift in Sources */,
 				3B061FE2292926DA00BFA71D /* SignUpBlogViewModel.swift in Sources */,

--- a/burstcamp/burstcamp/App/SceneDelegate.swift
+++ b/burstcamp/burstcamp/App/SceneDelegate.swift
@@ -18,7 +18,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         else {
             return
         }
-
+        appCoordinator.dismissNavigationController()
+        appCoordinator.displayIndicator()
         LogInManager.shared.logIn(code: code)
     }
 

--- a/burstcamp/burstcamp/Coordinator/App/AppCoordinator.swift
+++ b/burstcamp/burstcamp/Coordinator/App/AppCoordinator.swift
@@ -25,6 +25,19 @@ final class AppCoordinator: AppCoordinatorProtocol {
         addObserver()
     }
 
+    func dismissNavigationController() {
+        navigationController.dismiss(animated: true)
+    }
+
+    func displayIndicator() {
+        guard let authCoordinator = childCoordinators.first(
+            where: { $0 is AuthCoordinator }) as? AuthCoordinator
+        else {
+            return
+        }
+        authCoordinator.displayIndicator()
+    }
+
     func start() {
         LogInManager.shared.autoLogInPublisher
             .sink { [weak self] isLogIn in

--- a/burstcamp/burstcamp/Coordinator/Base/CoordinatorEvent.swift
+++ b/burstcamp/burstcamp/Coordinator/Base/CoordinatorEvent.swift
@@ -18,6 +18,7 @@ enum AuthCoordinatorEvent {
     case moveToBlogScreen
     case moveToTabBarScreen
     case showAlert(String)
+    case moveToGithubLogIn
 }
 
 enum TabBarCoordinatorEvent {

--- a/burstcamp/burstcamp/Scene/Auth/LogIn/LogInView.swift
+++ b/burstcamp/burstcamp/Scene/Auth/LogIn/LogInView.swift
@@ -76,6 +76,7 @@ final class LogInView: UIView {
 
     lazy var loadingLabel: UILabel = UILabel().then {
         $0.text = "캠퍼 인증 중"
+        $0.textColor = .dynamicBlack
         $0.isHidden = true
     }
 

--- a/burstcamp/burstcamp/Scene/Auth/LogIn/LogInView.swift
+++ b/burstcamp/burstcamp/Scene/Auth/LogIn/LogInView.swift
@@ -45,6 +45,11 @@ final class LogInView: UIView {
         $0.style = .large
     }
 
+    lazy var loadingLabel: UILabel = UILabel().then {
+        $0.text = "캠퍼 인증 중"
+        $0.isHidden = true
+    }
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         configureUI()
@@ -57,42 +62,55 @@ final class LogInView: UIView {
 
     private func configureUI() {
         backgroundColor = .background
+        addViews()
+        configureLayout()
+    }
 
+    private func addViews() {
         addSubview(titleImage)
+        addSubview(titleLabel)
+        addSubview(identitySentenceLabel)
+        addSubview(githubLogInButton)
+        addSubview(githubLogInLabel)
+        addSubview(activityIndicator)
+        addSubview(loadingLabel)
+    }
+
+    private func configureLayout() {
         titleImage.snp.makeConstraints {
             $0.height.width.equalTo(Constant.Image.appTitle)
             $0.centerY.equalToSuperview().offset(Constant.spaceMinus72)
             $0.leading.equalToSuperview().offset(Constant.space16)
         }
 
-        addSubview(titleLabel)
         titleLabel.snp.makeConstraints {
             $0.leading.equalTo(titleImage.snp.trailing)
             $0.centerY.equalToSuperview().offset(Constant.spaceMinus72)
         }
 
-        addSubview(identitySentenceLabel)
         identitySentenceLabel.snp.makeConstraints {
             $0.top.equalTo(titleLabel.snp.bottom).offset(Constant.space10)
             $0.leading.equalToSuperview().offset(Constant.space16)
         }
 
-        addSubview(githubLogInButton)
         githubLogInButton.snp.makeConstraints {
             $0.horizontalEdges.equalToSuperview().inset(Constant.space16)
             $0.height.equalTo(Constant.Button.githubLogInButtonHeight)
             $0.bottom.equalToSuperview().multipliedBy(0.9)
         }
 
-        addSubview(githubLogInLabel)
         githubLogInLabel.snp.makeConstraints {
             $0.top.equalTo(githubLogInButton.snp.bottom).offset(Constant.space12)
             $0.centerX.equalToSuperview()
         }
 
-        addSubview(activityIndicator)
         activityIndicator.snp.makeConstraints {
             $0.centerX.centerY.equalToSuperview()
+        }
+
+        loadingLabel.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.top.equalTo(activityIndicator.snp.bottom).offset(Constant.space10)
         }
     }
 }

--- a/burstcamp/burstcamp/Scene/Auth/LogIn/LogInView.swift
+++ b/burstcamp/burstcamp/Scene/Auth/LogIn/LogInView.swift
@@ -64,7 +64,7 @@ final class LogInView: UIView {
         }
     }()
 
-    private lazy var githubLogInLabel: UILabel = UILabel().then {
+    private lazy var camperAuthLabel: UILabel = UILabel().then {
         $0.text = "캠퍼 인증을 위해 Github으로 로그인을 해주세요."
         $0.font = UIFont.regular12
         $0.textColor = .systemGray2
@@ -100,7 +100,7 @@ final class LogInView: UIView {
         addSubview(titleLabel)
         addSubview(identitySentenceLabel)
         addSubview(camperAuthButton)
-        addSubview(githubLogInLabel)
+        addSubview(camperAuthLabel)
         addSubview(activityIndicator)
         addSubview(loadingLabel)
     }
@@ -124,7 +124,7 @@ final class LogInView: UIView {
 
         camperAuthButton.snp.makeConstraints {
             $0.horizontalEdges.equalToSuperview().inset(Constant.space16)
-            $0.height.equalTo(Constant.Button.githubLogInButtonHeight)
+            $0.height.equalTo(Constant.Button.camperAuthButtonHeight)
             $0.bottom.equalToSuperview().multipliedBy(0.9)
         }
 
@@ -137,7 +137,7 @@ final class LogInView: UIView {
             $0.center.equalToSuperview()
         }
 
-        githubLogInLabel.snp.makeConstraints {
+        camperAuthLabel.snp.makeConstraints {
             $0.top.equalTo(camperAuthButton.snp.bottom).offset(Constant.space12)
             $0.centerX.equalToSuperview()
         }

--- a/burstcamp/burstcamp/Scene/Auth/LogIn/LogInView.swift
+++ b/burstcamp/burstcamp/Scene/Auth/LogIn/LogInView.swift
@@ -27,13 +27,42 @@ final class LogInView: UIView {
         $0.font = UIFont.regular14
     }
 
-    lazy var githubLogInButton: UIButton = UIButton().then {
-        $0.setTitle("Github으로 로그인", for: .normal)
-        $0.titleLabel?.font = UIFont.extraBold14
-        $0.backgroundColor = .dynamicBlack
-        $0.setTitleColor(.dynamicWhite, for: .normal)
-        $0.layer.cornerRadius = CGFloat(Constant.CornerRadius.radius8)
-    }
+    lazy var camperAuthButton: UIButton = {
+        let button = UIButton()
+
+        if #available(iOS 15.0, *) {
+            var string = AttributedString("캠퍼 인증 시작하기")
+            string.font = UIFont.extraBold14
+            string.foregroundColor = .dynamicWhite
+
+            var configuration = UIButton.Configuration.filled()
+            configuration.attributedTitle = string
+            configuration.titleAlignment = .center
+
+            configuration.image = UIImage.github
+            configuration.imagePlacement = .leading
+            configuration.imagePadding = 50
+
+            configuration.baseBackgroundColor = .dynamicBlack
+            configuration.cornerStyle = .medium
+
+            button.configuration = configuration
+
+            return button
+        } else {
+            button.setTitle("캠퍼 인증 시작하기", for: .normal)
+            button.titleLabel?.font = UIFont.extraBold14
+            button.setTitleColor(.dynamicWhite, for: .normal)
+            button.titleLabel?.textAlignment = .center
+
+            button.setImage(UIImage.github, for: .normal)
+
+            button.backgroundColor = .dynamicBlack
+            button.layer.cornerRadius = CGFloat(Constant.CornerRadius.radius8)
+
+            return button
+        }
+    }()
 
     private lazy var githubLogInLabel: UILabel = UILabel().then {
         $0.text = "캠퍼 인증을 위해 Github으로 로그인을 해주세요."
@@ -70,7 +99,7 @@ final class LogInView: UIView {
         addSubview(titleImage)
         addSubview(titleLabel)
         addSubview(identitySentenceLabel)
-        addSubview(githubLogInButton)
+        addSubview(camperAuthButton)
         addSubview(githubLogInLabel)
         addSubview(activityIndicator)
         addSubview(loadingLabel)
@@ -93,14 +122,23 @@ final class LogInView: UIView {
             $0.leading.equalToSuperview().offset(Constant.space16)
         }
 
-        githubLogInButton.snp.makeConstraints {
+        camperAuthButton.snp.makeConstraints {
             $0.horizontalEdges.equalToSuperview().inset(Constant.space16)
             $0.height.equalTo(Constant.Button.githubLogInButtonHeight)
             $0.bottom.equalToSuperview().multipliedBy(0.9)
         }
 
+        camperAuthButton.imageView?.snp.makeConstraints {
+            $0.trailing.equalToSuperview().multipliedBy(0.15)
+            $0.centerY.equalToSuperview()
+        }
+
+        camperAuthButton.titleLabel?.snp.makeConstraints {
+            $0.center.equalToSuperview()
+        }
+
         githubLogInLabel.snp.makeConstraints {
-            $0.top.equalTo(githubLogInButton.snp.bottom).offset(Constant.space12)
+            $0.top.equalTo(camperAuthButton.snp.bottom).offset(Constant.space12)
             $0.centerX.equalToSuperview()
         }
 

--- a/burstcamp/burstcamp/Scene/Auth/LogIn/LoginViewController.swift
+++ b/burstcamp/burstcamp/Scene/Auth/LogIn/LoginViewController.swift
@@ -52,12 +52,14 @@ final class LogInViewController: UIViewController {
             .sink {
                 LogInManager.shared.openGithubLoginView()
                 self.logInView.activityIndicator.startAnimating()
+                self.logInView.loadingLabel.isHidden = false
             }
             .store(in: &cancelBag)
 
         output.moveToOtherView
             .sink { logInEvent in
                 self.logInView.activityIndicator.stopAnimating()
+                self.logInView.loadingLabel.isHidden = true
 
                 switch logInEvent {
                 case .moveToDomainScreen:

--- a/burstcamp/burstcamp/Scene/Auth/LogIn/LoginViewController.swift
+++ b/burstcamp/burstcamp/Scene/Auth/LogIn/LoginViewController.swift
@@ -43,7 +43,7 @@ final class LogInViewController: UIViewController {
 
     private func bind() {
         let input = LogInViewModel.Input(
-            logInButtonDidTap: logInView.githubLogInButton.tapPublisher
+            logInButtonDidTap: logInView.camperAuthButton.tapPublisher
         )
 
         let output = viewModel.transform(input: input)

--- a/burstcamp/burstcamp/Scene/Auth/LogIn/LoginViewController.swift
+++ b/burstcamp/burstcamp/Scene/Auth/LogIn/LoginViewController.swift
@@ -41,6 +41,11 @@ final class LogInViewController: UIViewController {
         bind()
     }
 
+    func displayIndicator() {
+        logInView.activityIndicator.startAnimating()
+        logInView.loadingLabel.isHidden = false
+    }
+
     private func bind() {
         let input = LogInViewModel.Input(
             logInButtonDidTap: logInView.camperAuthButton.tapPublisher
@@ -50,9 +55,7 @@ final class LogInViewController: UIViewController {
 
         output.openLogInView
             .sink {
-                LogInManager.shared.openGithubLoginView()
-                self.logInView.activityIndicator.startAnimating()
-                self.logInView.loadingLabel.isHidden = false
+                self.coordinatorPublisher.send(.moveToGithubLogIn)
             }
             .store(in: &cancelBag)
 
@@ -68,7 +71,7 @@ final class LogInViewController: UIViewController {
                     self.coordinatorPublisher.send(.moveToTabBarScreen)
                 case .showAlert(let message):
                     self.showAlert(message: message)
-                case .moveToBlogScreen, .moveToIDScreen:
+                case .moveToBlogScreen, .moveToIDScreen, .moveToGithubLogIn:
                     return
                 }
             }

--- a/burstcamp/burstcamp/Scene/Auth/SignUp/Blog/SignUpBlogView.swift
+++ b/burstcamp/burstcamp/Scene/Auth/SignUp/Blog/SignUpBlogView.swift
@@ -63,6 +63,16 @@ final class SignUpBlogView: UIView {
         $0.style = .large
     }
 
+    lazy var confirmBlogLabel: UILabel = UILabel().then {
+        $0.text = "블로그 주소 검증 중"
+        $0.isHidden = true
+    }
+
+    lazy var signUpLabel: UILabel = UILabel().then {
+        $0.text = "가입 중"
+        $0.isHidden = true
+    }
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         configureUI()
@@ -74,27 +84,37 @@ final class SignUpBlogView: UIView {
 
     private func configureUI() {
         backgroundColor = .background
+        addViews()
+        configureLayout()
+    }
 
+    private func addViews() {
         addSubview(mainLabel)
+        addSubview(subLabel)
+        addSubview(blogTextField)
+        addSubview(skipButton)
+        addSubview(activityIndicator)
+        addSubview(confirmBlogLabel)
+        addSubview(signUpLabel)
+    }
+
+    private func configureLayout() {
         mainLabel.snp.makeConstraints {
             $0.bottom.equalToSuperview().multipliedBy(0.2)
             $0.leading.equalToSuperview().offset(Constant.space16)
         }
 
-        addSubview(subLabel)
         subLabel.snp.makeConstraints {
             $0.top.equalTo(mainLabel.snp.bottom).offset(Constant.space10)
             $0.leading.equalToSuperview().offset(Constant.space16)
         }
 
-        addSubview(blogTextField)
         blogTextField.snp.makeConstraints {
             $0.horizontalEdges.equalToSuperview().inset(Constant.space24)
             $0.height.equalTo(Constant.TextField.camperIDHeight)
             $0.top.equalTo(subLabel.snp.bottom).offset(Constant.space32)
         }
 
-        addSubview(skipButton)
         skipButton.snp.makeConstraints {
             $0.leading.equalToSuperview().offset(Constant.space24)
             $0.top.equalTo(blogTextField.snp.bottom).offset(Constant.space8)
@@ -108,9 +128,18 @@ final class SignUpBlogView: UIView {
             $0.height.equalTo(Constant.space48)
         }
 
-        addSubview(activityIndicator)
         activityIndicator.snp.makeConstraints {
             $0.centerX.centerY.equalToSuperview()
+        }
+
+        confirmBlogLabel.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.top.equalTo(activityIndicator.snp.bottom).offset(Constant.space10)
+        }
+
+        signUpLabel.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.top.equalTo(activityIndicator.snp.bottom).offset(Constant.space10)
         }
     }
 }

--- a/burstcamp/burstcamp/Scene/Auth/SignUp/Blog/SignUpBlogViewController.swift
+++ b/burstcamp/burstcamp/Scene/Auth/SignUp/Blog/SignUpBlogViewController.swift
@@ -39,16 +39,17 @@ final class SignUpBlogViewController: UIViewController {
     }
 
     private func bind() {
-        let nextButtonSubject = PassthroughSubject<Bool, Never>()
-        let skipConfirmSubject = PassthroughSubject<Bool, Never>()
+        let nextButtonSubject = PassthroughSubject<Void, Never>()
+        let skipConfirmSubject = PassthroughSubject<Void, Never>()
         let blogTitleConfirmSubject = PassthroughSubject<String, Never>()
         let saveFCMToken = PassthroughSubject<Void, Never>()
 
         signUpBlogView.skipButton.tapPublisher
             .sink { _ in
                 let confirmAction = UIAlertAction(title: "네", style: .default) { _ in
-                    skipConfirmSubject.send(true)
+                    skipConfirmSubject.send()
                     self.signUpBlogView.activityIndicator.startAnimating()
+                    self.signUpBlogView.signUpLabel.isHidden = false
                 }
                 let cancelAction = UIAlertAction(title: "아니오", style: .destructive)
                 self.showAlert(
@@ -60,8 +61,9 @@ final class SignUpBlogViewController: UIViewController {
 
         signUpBlogView.nextButton.tapPublisher
             .sink { _ in
+                nextButtonSubject.send()
                 self.signUpBlogView.activityIndicator.startAnimating()
-                nextButtonSubject.send(true)
+                self.signUpBlogView.confirmBlogLabel.isHidden = false
             }
             .store(in: &cancelBag)
 
@@ -85,6 +87,7 @@ final class SignUpBlogViewController: UIViewController {
         output.signUpWithNextButton
             .sink { blogTitle in
                 self.signUpBlogView.activityIndicator.stopAnimating()
+                self.signUpBlogView.confirmBlogLabel.isHidden = true
 
                 if blogTitle.isEmpty {
                     self.showAlert(message: "블로그 주소를 확인해주세요")
@@ -92,6 +95,7 @@ final class SignUpBlogViewController: UIViewController {
                     let confirmAction = UIAlertAction(title: "네", style: .default) { _ in
                         blogTitleConfirmSubject.send(blogTitle)
                         self.signUpBlogView.activityIndicator.startAnimating()
+                        self.signUpBlogView.signUpLabel.isHidden = false
                     }
                     let cancelAction = UIAlertAction(title: "아니오", style: .destructive)
                     self.showAlert(
@@ -105,6 +109,7 @@ final class SignUpBlogViewController: UIViewController {
         output.signUpWithBlogTitle
             .sink(receiveCompletion: { result in
                 self.signUpBlogView.activityIndicator.stopAnimating()
+                self.signUpBlogView.signUpLabel.isHidden = true
                 if case .failure = result {
                     self.showAlert(message: "회원가입에 실패했습니다")
                 }
@@ -117,6 +122,7 @@ final class SignUpBlogViewController: UIViewController {
         output.signUpWithSkipButton
             .sink(receiveCompletion: { result in
                 self.signUpBlogView.activityIndicator.stopAnimating()
+                self.signUpBlogView.signUpLabel.isHidden = true
                 if case .failure = result {
                     self.showAlert(message: "회원가입에 실패했습니다")
                 }

--- a/burstcamp/burstcamp/Scene/Auth/SignUp/Blog/SignUpBlogViewModel.swift
+++ b/burstcamp/burstcamp/Scene/Auth/SignUp/Blog/SignUpBlogViewModel.swift
@@ -55,7 +55,7 @@ final class SignUpBlogViewModel {
                         blogURL: LogInManager.shared.blodURL,
                         blogTitle: title
                     ) else {
-                        promise(.failure(FirestoreError.noDataError))
+                        promise(.failure(FirebaseAuthError.fetchUUIDError))
                         return
                     }
                     promise(.success(user))

--- a/burstcamp/burstcamp/Scene/Auth/SignUp/Blog/SignUpBlogViewModel.swift
+++ b/burstcamp/burstcamp/Scene/Auth/SignUp/Blog/SignUpBlogViewModel.swift
@@ -12,8 +12,8 @@ final class SignUpBlogViewModel {
 
     struct Input {
         let blogAddressTextFieldDidEdit: AnyPublisher<String, Never>
-        let nextButtonDidTap: PassthroughSubject<Bool, Never>
-        let skipConfirmDidTap: PassthroughSubject<Bool, Never>
+        let nextButtonDidTap: PassthroughSubject<Void, Never>
+        let skipConfirmDidTap: PassthroughSubject<Void, Never>
         let blogTitleConfirmDidTap: PassthroughSubject<String, Never>
         let saveFCMToken: PassthroughSubject<Void, Never>
     }

--- a/burstcamp/burstcamp/Scene/Auth/SignUp/Blog/SignUpBlogViewModel.swift
+++ b/burstcamp/burstcamp/Scene/Auth/SignUp/Blog/SignUpBlogViewModel.swift
@@ -72,7 +72,7 @@ final class SignUpBlogViewModel {
             .flatMap { _ -> AnyPublisher<User, Error> in
                 return Future<User, Error> { promise in
                     guard let user = try? self.createUser(blogURL: "", blogTitle: "") else {
-                        promise(.failure(FirestoreError.noDataError))
+                        promise(.failure(FirebaseAuthError.fetchUUIDError))
                         return
                     }
                     promise(.success(user))
@@ -98,7 +98,7 @@ final class SignUpBlogViewModel {
 
     private func createUser(blogURL: String, blogTitle: String) throws -> User {
         guard let userUUID = LogInManager.shared.userUUID else {
-            throw FirestoreError.noDataError
+            throw FirebaseAuthError.fetchUUIDError
         }
 
         return User(

--- a/burstcamp/burstcamp/Scene/Auth/SignUp/CamperID/SignUpCamperIDView.swift
+++ b/burstcamp/burstcamp/Scene/Auth/SignUp/CamperID/SignUpCamperIDView.swift
@@ -69,32 +69,39 @@ final class SignUpCamperIDView: UIView {
 
     func configureUI() {
         backgroundColor = .background
+        addViews()
+        configureLayout()
+    }
 
+    private func addViews() {
         addSubview(domainLabel)
+        addSubview(mainLabel)
+        addSubview(subLabel)
+        addSubview(representingDomainLabel)
+        addSubview(idTextField)
+    }
+
+    private func configureLayout() {
         domainLabel.snp.makeConstraints {
             $0.bottom.equalToSuperview().multipliedBy(0.2)
             $0.leading.equalToSuperview().offset(Constant.space16)
         }
 
-        addSubview(mainLabel)
         mainLabel.snp.makeConstraints {
             $0.bottom.equalToSuperview().multipliedBy(0.2)
             $0.leading.equalTo(domainLabel.snp.trailing).offset(Constant.space8)
         }
 
-        addSubview(subLabel)
         subLabel.snp.makeConstraints {
             $0.top.equalTo(mainLabel.snp.bottom).offset(Constant.space8)
             $0.leading.equalToSuperview().offset(Constant.space16)
         }
 
-        addSubview(representingDomainLabel)
         representingDomainLabel.snp.makeConstraints {
             $0.bottom.equalToSuperview().multipliedBy(0.35)
             $0.leading.equalToSuperview().offset(Constant.space24)
         }
 
-        addSubview(idTextField)
         idTextField.snp.makeConstraints {
             $0.centerY.equalTo(representingDomainLabel.snp.centerY)
             $0.leading.equalTo(representingDomainLabel.snp.trailing).offset(Constant.space12)

--- a/burstcamp/burstcamp/Scene/Auth/SignUp/Domain/SighUpDomainView.swift
+++ b/burstcamp/burstcamp/Scene/Auth/SignUp/Domain/SighUpDomainView.swift
@@ -53,20 +53,29 @@ final class SignUpDomainView: UIView {
 
     private func configureUI() {
         backgroundColor = .background
+        addViews()
+        configureLayout()
+    }
 
+    private func addViews() {
         addSubview(mainLabel)
+        addSubview(subLabel)
+        addSubview(webButton)
+        addSubview(aosButton)
+        addSubview(iosButton)
+    }
+
+    private func configureLayout() {
         mainLabel.snp.makeConstraints {
             $0.bottom.equalToSuperview().multipliedBy(0.2)
             $0.leading.equalToSuperview().offset(Constant.space16)
         }
 
-        addSubview(subLabel)
         subLabel.snp.makeConstraints {
             $0.top.equalTo(mainLabel.snp.bottom).offset(Constant.space8)
             $0.leading.equalToSuperview().offset(Constant.space16)
         }
 
-        addSubview(webButton)
         webButton.snp.makeConstraints {
             $0.width.equalTo(Constant.Button.domainWidth)
             $0.height.equalTo(Constant.Button.domainHeight)
@@ -74,7 +83,6 @@ final class SignUpDomainView: UIView {
             $0.bottom.equalToSuperview().multipliedBy(0.45)
         }
 
-        addSubview(aosButton)
         aosButton.snp.makeConstraints {
             $0.width.equalTo(Constant.Button.domainWidth)
             $0.height.equalTo(Constant.Button.domainHeight)
@@ -82,7 +90,6 @@ final class SignUpDomainView: UIView {
             $0.top.equalTo(webButton.snp.bottom).offset(Constant.space48)
         }
 
-        addSubview(iosButton)
         iosButton.snp.makeConstraints {
             $0.width.equalTo(Constant.Button.domainWidth)
             $0.height.equalTo(Constant.Button.domainHeight)

--- a/burstcamp/burstcamp/Service/KeyChainManager.swift
+++ b/burstcamp/burstcamp/Service/KeyChainManager.swift
@@ -11,11 +11,19 @@ import Security
 struct KeyChainManager {
 
     static let userAccount = "userAccount"
+    static let githubToken = "githubToken"
 
     static func save(user: User) {
         guard let data = try? JSONEncoder().encode(user) else { return }
 
         let query = saveUserQuery(data: data)
+        SecItemAdd(query, nil)
+    }
+
+    static func save(token: String) {
+        guard let data = try? JSONEncoder().encode(token) else { return }
+
+        let query = saveTokenQuery(data: data)
         SecItemAdd(query, nil)
     }
 
@@ -32,8 +40,26 @@ struct KeyChainManager {
         return user
     }
 
+    static func readToken() -> String? {
+        let query = readTokenQuery()
+        var item: CFTypeRef?
+
+        if SecItemCopyMatching(query, &item) != errSecSuccess { return nil }
+
+        guard let item = item as? [CFString: Any],
+              let data = item[kSecAttrGeneric] as? Data,
+              let token = try? JSONDecoder().decode(String.self, from: data)
+        else { return nil }
+        return token
+    }
+
     static func deleteUser() {
         let query = deleteUserQuery()
+        SecItemDelete(query)
+    }
+
+    static func deleteToken() {
+        let query = deleteTokenQuery()
         SecItemDelete(query)
     }
 
@@ -41,6 +67,14 @@ struct KeyChainManager {
         return [
             kSecClass: kSecClassGenericPassword,
             kSecAttrAccount: userAccount,
+            kSecAttrGeneric: data
+        ] as CFDictionary
+    }
+
+    private static func saveTokenQuery(data: Data) -> CFDictionary {
+        return [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrAccount: githubToken,
             kSecAttrGeneric: data
         ] as CFDictionary
     }
@@ -55,10 +89,27 @@ struct KeyChainManager {
         ] as CFDictionary
     }
 
+    private static func readTokenQuery() -> CFDictionary {
+        return [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrAccount: githubToken,
+            kSecMatchLimit: kSecMatchLimitOne,
+            kSecReturnAttributes: true,
+            kSecReturnData: true
+        ] as CFDictionary
+    }
+
     private static func deleteUserQuery() -> CFDictionary {
         return [
             kSecClass: kSecClassGenericPassword,
             kSecAttrAccount: userAccount
+        ] as CFDictionary
+    }
+
+    private static func deleteTokenQuery() -> CFDictionary {
+        return [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrAccount: githubToken
         ] as CFDictionary
     }
 }

--- a/burstcamp/burstcamp/Service/LogInManager.swift
+++ b/burstcamp/burstcamp/Service/LogInManager.swift
@@ -176,7 +176,6 @@ final class LogInManager {
                                 promise(.failure(.userSignOutError))
                                 return
                             }
-                            KeyChainManager.deleteToken()
                             promise(.success(true))
                         }
                     }

--- a/burstcamp/burstcamp/Service/LogInManager.swift
+++ b/burstcamp/burstcamp/Service/LogInManager.swift
@@ -112,7 +112,7 @@ final class LogInManager {
                 self.logInPublisher.send(.showAlert(FirebaseAuthError.failSignInError.errorDescription ?? ""))
                 return
             }
-            
+
             KeyChainManager.save(token: token)
             self.isSignedUp(uuid: result.user.uid)
         }
@@ -161,7 +161,7 @@ final class LogInManager {
         }
         .eraseToAnyPublisher()
     }
-    
+
     func requestGithubAccessToken(code: String) -> AnyPublisher<GithubToken, GithubError> {
         let urlString = "https://github.com/login/oauth/access_token"
 

--- a/burstcamp/burstcamp/Service/LogInManager.swift
+++ b/burstcamp/burstcamp/Service/LogInManager.swift
@@ -32,7 +32,7 @@ final class LogInManager {
     var camperID: String = ""
     var blodURL: String = ""
 
-    private var githubAPIKey: Github? {
+    var githubAPIKey: Github? {
         guard let serviceInfoURL = Bundle.main.url(
             forResource: "Service-Info",
             withExtension: "plist"
@@ -58,25 +58,6 @@ final class LogInManager {
                 self?.autoLogInPublisher.send(true)
             }
             .store(in: &cancelBag)
-    }
-
-    func openGithubLoginView() {
-        let urlString = "https://github.com/login/oauth/authorize"
-
-        guard var urlComponent = URLComponents(string: urlString),
-              let clientID = githubAPIKey?.clientID
-        else {
-            return
-        }
-
-        urlComponent.queryItems = [
-            URLQueryItem(name: "client_id", value: clientID),
-            URLQueryItem(name: "scope", value: "admin:org")
-        ]
-
-        guard let url = urlComponent.url else { return }
-
-        UIApplication.shared.open(url)
     }
 
     func logIn(code: String) {
@@ -109,7 +90,9 @@ final class LogInManager {
             guard let result = result,
                   error == nil
             else {
-                self.logInPublisher.send(.showAlert(FirebaseAuthError.failSignInError.errorDescription ?? ""))
+                self.logInPublisher.send(
+                    .showAlert(FirebaseAuthError.failSignInError.errorDescription ?? "")
+                )
                 return
             }
 

--- a/burstcamp/burstcamp/Util/Constant/Constant.swift
+++ b/burstcamp/burstcamp/Util/Constant/Constant.swift
@@ -64,7 +64,7 @@ enum Constant {
         static let script = 24
         static let editButton = 40
         static let defaultButton = 48
-        static let githubLogInButtonHeight = 48
+        static let camperAuthButtonHeight = 48
         static let domainWidth = 120
         static let domainHeight = 60
         static let camera = 24

--- a/burstcamp/burstcamp/Util/Error/FirebaseAuthError.swift
+++ b/burstcamp/burstcamp/Util/Error/FirebaseAuthError.swift
@@ -1,0 +1,30 @@
+//
+//  FirebaseAuthError.swift
+//  burstcamp
+//
+//  Created by 김기훈 on 2022/12/09.
+//
+
+import Foundation
+
+enum FirebaseAuthError: LocalizedError {
+    case failSignInError
+    case readTokenError
+    case userReAuthError
+    case userDeleteError
+    case authSignOutError
+    case fetchUUIDError
+}
+
+extension FirebaseAuthError {
+    var errorDescription: String? {
+        switch self {
+        case .failSignInError: return "Fail to firebase auth signIn"
+        case .readTokenError: return "토큰을 불러올 수 없습니다"
+        case .userReAuthError: return "재인증을 하던 중 에러가 발생했습니다."
+        case .userDeleteError: return "유저를 삭제하던 중 에러가 발생했습니다."
+        case .authSignOutError: return "Fail to auth sign out"
+        case .fetchUUIDError: return "UUID에 접근 하던 중 에러가 발생했습니다"
+        }
+    }
+}

--- a/burstcamp/burstcamp/Util/Error/FirestoreError.swift
+++ b/burstcamp/burstcamp/Util/Error/FirestoreError.swift
@@ -10,9 +10,6 @@ enum FirestoreError: LocalizedError {
 
     /// 유저
     case fetchUserError
-    case userDeleteError
-    case userSignOutError
-    case userReAuthError
     case setDataError
     case noDataError
     case updateError
@@ -30,9 +27,6 @@ extension FirestoreError {
         switch self {
         /// 유저
         case .fetchUserError: return "유저를 불러오던 중 에러가 발생했습니다."
-        case .userDeleteError: return "유저를 삭제하던 중 에러가 발생했습니다."
-        case .userSignOutError: return "로그아웃 하던 중 에러가 발생했습니다."
-        case .userReAuthError: return "재인증을 하던 중 에러가 발생했습니다."
         case .setDataError: return "유저를 설정하는 중 에러가 발생했습니다."
         case .noDataError: return "응답 데이터가 없습니다."
         case .updateError: return "유저를 업데이트하던 중 에러가 발생합니다."

--- a/burstcamp/burstcamp/Util/Error/FirestoreError.swift
+++ b/burstcamp/burstcamp/Util/Error/FirestoreError.swift
@@ -12,6 +12,7 @@ enum FirestoreError: LocalizedError {
     case fetchUserError
     case userDeleteError
     case userSignOutError
+    case userReAuthError
     case setDataError
     case noDataError
     case updateError
@@ -31,6 +32,7 @@ extension FirestoreError {
         case .fetchUserError: return "유저를 불러오던 중 에러가 발생했습니다."
         case .userDeleteError: return "유저를 삭제하던 중 에러가 발생했습니다."
         case .userSignOutError: return "로그아웃 하던 중 에러가 발생했습니다."
+        case .userReAuthError: return "재인증을 하던 중 에러가 발생했습니다."
         case .setDataError: return "유저를 설정하는 중 에러가 발생했습니다."
         case .noDataError: return "응답 데이터가 없습니다."
         case .updateError: return "유저를 업데이트하던 중 에러가 발생합니다."

--- a/modules/BCResource/BCResource/Generated/Assets+Generated.swift
+++ b/modules/BCResource/BCResource/Generated/Assets+Generated.swift
@@ -44,8 +44,8 @@ public enum Assets {
     public static let yellow = ColorAsset(name: "yellow")
   }
   public enum Image {
+    public static let github = ImageAsset(name: "Github")
     public static let burstcamper100 = ImageAsset(name: "burstcamper100")
-    public static let github = ImageAsset(name: "github")
   }
 }
 // swiftlint:enable identifier_name line_length nesting type_body_length type_name


### PR DESCRIPTION
## 관련 이슈
- close #200 
- close #206 
- close #199 

## 내용
- 변경전
<img src="https://user-images.githubusercontent.com/54696445/206400225-0ee8d6e8-4ee8-4c6e-bc61-d3427a857adb.gif" width=324>

### iOS14
<img src="https://user-images.githubusercontent.com/54696445/206445932-6600eee7-5f97-469d-98fc-3de3e3f8538e.png" width=324>

### iOS16
<img src="https://user-images.githubusercontent.com/54696445/206445945-c795865c-9b16-4674-81f1-79f4cec14b72.png" width=324>


- 변경후
<img src="https://user-images.githubusercontent.com/54696445/206706148-ea549cdf-5f04-4b6b-a75a-afbf84cbee3f.gif" width=324>


- 리뷰어님께서 말씀하신 뷰 추가와 레이아웃 처리하는 부분 분리
- indicator아래에 상태설명 라벨 추가
- 회원가입시 토큰 저장
- 탈퇴시 토큰을 이용한 재인증 후 탈퇴처리
- 캠퍼 인증 버튼에 github 로고 추가

## 리뷰어가 확인할 사항
- addViews, configureLayout으로 해놨는데 더 좋은 이름 추천받습니다
- 디자이너님께서는 indicator아래 label의 글자 색과 크기 등을 알려주시면 수정하겠습니다
