### PR TITLE
[푸시알림] 탭했을시 Coordinator 이동

### DIFF
--- a/burstcamp/burstcamp/App/AppDelegate.swift
+++ b/burstcamp/burstcamp/App/AppDelegate.swift
@@ -46,7 +46,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
 extension AppDelegate: UNUserNotificationCenterDelegate {
 
-    /// receive push noti when app is foreground
     func userNotificationCenter(
         _ center: UNUserNotificationCenter,
         willPresent notification: UNNotification,
@@ -58,7 +57,6 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         completionHandler([.banner, .badge, .sound])
     }
 
-    /// receive push noti when app is background
     func userNotificationCenter(
         _ center: UNUserNotificationCenter,
         didReceive response: UNNotificationResponse,

--- a/burstcamp/burstcamp/App/AppDelegate.swift
+++ b/burstcamp/burstcamp/App/AppDelegate.swift
@@ -53,7 +53,7 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
             UNNotificationPresentationOptions
         ) -> Void
     ) {
-        UserDefaultsManager.save(isForeground: "true")
+        UserDefaultsManager.save(isForeground: true)
         completionHandler([.banner, .badge, .sound])
     }
 
@@ -69,7 +69,7 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         else { return }
 
         UserDefaultsManager.save(notificationFeedUUID: feedUUID)
-        if UserDefaultsManager.isForeground() != nil {
+        if UserDefaultsManager.isForeground() {
             NotificationCenter.default.post(name: .Push, object: nil)
         }
     }

--- a/burstcamp/burstcamp/App/AppDelegate.swift
+++ b/burstcamp/burstcamp/App/AppDelegate.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import UserNotifications
 
 import BCResource
 import Firebase
@@ -20,22 +21,29 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     ) -> Bool {
         FirebaseApp.configure()
         UserManager.shared.appStart()
-        // TODO: 삭제
         print("Auth.auth().currentUser?.uid 값이에오: ", Auth.auth().currentUser?.uid)
         print("키체인에 있던 유저의 UUID 값이에오: ", UserManager.shared.user.userUUID)
         configurePushNotification(application)
         configureMessaging()
         return true
     }
+
+    func application(
+        _ application: UIApplication,
+        didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
+    ) {
+        Messaging.messaging().apnsToken = deviceToken
+    }
+
+    private func configurePushNotification(_ application: UIApplication) {
+        UNUserNotificationCenter.current().delegate = self
+        application.registerForRemoteNotifications()
+    }
 }
 
 // MARK: - UNUserNotificationCenterDelegate
 
 extension AppDelegate: UNUserNotificationCenterDelegate {
-    private func configurePushNotification(_ application: UIApplication) {
-        UNUserNotificationCenter.current().delegate = self
-        application.registerForRemoteNotifications()
-    }
 
     /// receive push noti when app is foreground
     func userNotificationCenter(
@@ -45,17 +53,7 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
             UNNotificationPresentationOptions
         ) -> Void
     ) {
-        let userInfo = notification.request.content.userInfo
-        // TODO: userInfo -> feedUUID
-        print(userInfo)
-        DispatchQueue.main.async {
-            NotificationCenter.default.post(
-                name: .Push,
-                object: nil,
-                userInfo: userInfo
-            )
-        }
-
+        UserDefaultsManager.save(isForeground: "true")
         completionHandler([.banner, .badge, .sound])
     }
 
@@ -65,14 +63,15 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         didReceive response: UNNotificationResponse,
         withCompletionHandler completionHandler: @escaping () -> Void
     ) {
-        let userInfo = response.notification.request.content.userInfo
-        // TODO: userInfo -> feedUUID
-        print(userInfo)
-        NotificationCenter.default.post(
-            name: .Push,
-            object: nil,
-            userInfo: userInfo
-        )
+        guard let feedUUID = response.notification.request.content.userInfo[
+            NotificationKey.feedUUID
+        ] as? String
+        else { return }
+
+        UserDefaultsManager.save(notificationFeedUUID: feedUUID)
+        if UserDefaultsManager.isForeground() != nil {
+            NotificationCenter.default.post(name: .Push, object: nil)
+        }
     }
 }
 
@@ -82,11 +81,15 @@ extension AppDelegate: MessagingDelegate {
     private func configureMessaging() {
         Messaging.messaging().delegate = self
         Messaging.messaging().token { token, error in
-            if let token = token {
+            if let token = token,
+               let savedToken = UserDefaultsManager.fcmToken(),
+               token != savedToken {
                 // TODO: 삭제
                 print("현재 UserManager에 있는 userUUID", UserManager.shared.user.userUUID)
-                print("의 토큰 값이에오: ", token)
+                print("의 토큰 값: ", token)
+                print("저장되어있던 토큰 값: ", savedToken)
                 UserDefaultsManager.save(fcmToken: token)
+                FirebaseFCMToken.save(fcmToken: token, to: UserManager.shared.user.userUUID)
             }
         }
     }
@@ -97,6 +100,7 @@ extension AppDelegate: MessagingDelegate {
         didReceiveRegistrationToken fcmToken: String?
     ) {
         if let fcmToken = fcmToken {
+            print("리프레쉬 fcmToken", fcmToken)
             if UserManager.shared.user.userUUID.isEmpty {
                 UserDefaultsManager.save(fcmToken: fcmToken)
             } else {
@@ -107,7 +111,7 @@ extension AppDelegate: MessagingDelegate {
 }
 
 // MARK: - save user in keychain
-
+// TODO: https://medium.com/cashwalk/ios-background-mode-9bf921f1c55b
 extension AppDelegate {
     func applicationWillTerminate(_ application: UIApplication) {
         KeyChainManager.deleteUser()

--- a/burstcamp/burstcamp/App/AppDelegate.swift
+++ b/burstcamp/burstcamp/App/AppDelegate.swift
@@ -37,6 +37,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     private func configurePushNotification(_ application: UIApplication) {
         UNUserNotificationCenter.current().delegate = self
+        UserDefaultsManager.removeIsForeground()
         application.registerForRemoteNotifications()
     }
 }

--- a/burstcamp/burstcamp/App/Info.plist
+++ b/burstcamp/burstcamp/App/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>FirebaseAppDelegateProxyEnabled</key>
+	<string>NO</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/burstcamp/burstcamp/Coordinator/App/AppCoordinator.swift
+++ b/burstcamp/burstcamp/Coordinator/App/AppCoordinator.swift
@@ -11,7 +11,6 @@ import UIKit
 protocol AppCoordinatorProtocol: NormalCoordinator {
     func showAuthFlow()
     func showTabBarFlow()
-    func showTabBarFlowByPushNotification(feedUUID: String)
 }
 
 final class AppCoordinator: AppCoordinatorProtocol {
@@ -22,7 +21,6 @@ final class AppCoordinator: AppCoordinatorProtocol {
     init(navigationController: UINavigationController) {
         self.navigationController = navigationController
         configureNavigationBar()
-        addObserver()
     }
 
     func dismissNavigationController() {
@@ -84,45 +82,6 @@ final class AppCoordinator: AppCoordinatorProtocol {
             .store(in: &cancelBag)
         childCoordinators.append(tabBarCoordinator)
         tabBarCoordinator.start()
-    }
-
-    func showTabBarFlowByPushNotification(feedUUID: String) {
-        if let tabBarCoordinator = tabBarCoordinator() {
-            moveToFeedDetail(tabBarCoordinator: tabBarCoordinator, feedUUID: feedUUID)
-        } else {
-            showTabBarFlow()
-            if let tabBarCoordinator = tabBarCoordinator() {
-                moveToFeedDetail(tabBarCoordinator: tabBarCoordinator, feedUUID: feedUUID)
-            }
-        }
-    }
-
-    private func moveToFeedDetail(tabBarCoordinator: TabBarCoordinator, feedUUID: String) {
-        let homeCoordinator = tabBarCoordinator.getHomeCoordinator()
-        homeCoordinator?.moveToFeedDetail(feedUUID: feedUUID)
-    }
-
-    private func addObserver() {
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(receivePushNotification(_:)),
-            name: .Push,
-            object: nil
-        )
-    }
-
-    @objc private func receivePushNotification(_ notification: Notification) {
-        guard let feedUUID = notification.userInfo?[NotificationKey.feedUUID] as? String
-        else { return }
-        showTabBarFlowByPushNotification(feedUUID: feedUUID)
-    }
-
-    private func tabBarCoordinator() -> TabBarCoordinator? {
-        if let childCoordinator = childCoordinators.first(where: { $0 is TabBarCoordinator }),
-           let tabBarCoordinator = childCoordinator as? TabBarCoordinator {
-            return tabBarCoordinator
-        }
-        return nil
     }
 
     private func configureNavigationBar() {

--- a/burstcamp/burstcamp/Coordinator/Home/HomeCoordinator.swift
+++ b/burstcamp/burstcamp/Coordinator/Home/HomeCoordinator.swift
@@ -61,7 +61,7 @@ extension HomeCoordinator {
 
 extension HomeCoordinator {
     private func checkNotificationFeed() {
-        if UserDefaultsManager.isForeground() == nil,
+        if !UserDefaultsManager.isForeground(),
            let feedUUID = UserDefaultsManager.notificationFeedUUID() {
             UserDefaultsManager.removeNotificationFeedUUID()
             moveToFeedDetail(feedUUID: feedUUID)

--- a/burstcamp/burstcamp/Coordinator/Home/HomeCoordinator.swift
+++ b/burstcamp/burstcamp/Coordinator/Home/HomeCoordinator.swift
@@ -40,6 +40,8 @@ extension HomeCoordinator {
                 }
             }
             .store(in: &cancelBag)
+
+        checkNotificationFeed()
     }
 
     func moveToFeedDetail(feed: Feed) {
@@ -52,5 +54,17 @@ extension HomeCoordinator {
         let feedDetailViewController = prepareFeedDetailViewController(feedUUID: feedUUID)
         sinkFeedViewController(feedDetailViewController)
         self.navigationController.pushViewController(feedDetailViewController, animated: true)
+    }
+}
+
+// MARK: - handle push notification
+
+extension HomeCoordinator {
+    private func checkNotificationFeed() {
+        if UserDefaultsManager.isForeground() == nil,
+           let feedUUID = UserDefaultsManager.notificationFeedUUID() {
+            UserDefaultsManager.removeNotificationFeedUUID()
+            moveToFeedDetail(feedUUID: feedUUID)
+        }
     }
 }

--- a/burstcamp/burstcamp/Coordinator/TabBar/TabBarCoordinator.swift
+++ b/burstcamp/burstcamp/Coordinator/TabBar/TabBarCoordinator.swift
@@ -29,6 +29,7 @@ final class TabBarCoordinator: TabBarCoordinatorProtocol {
 
     init(navigationController: UINavigationController) {
         self.navigationController = navigationController
+        addObserver()
     }
 
     func start() {
@@ -125,5 +126,27 @@ extension TabBarCoordinator {
             type(of: $0) == HomeCoordinator.self
         } as? HomeCoordinator
         return homeCoordinator
+    }
+}
+
+// MARK: - handle Push Notification
+
+extension TabBarCoordinator: ContainFeedDetailCoordinator {
+    private func addObserver() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(moveToDetail),
+            name: .Push,
+            object: nil
+        )
+    }
+
+    @objc func moveToDetail() {
+        guard let feedUUID = UserDefaultsManager.notificationFeedUUID() else { return }
+        UserDefaultsManager.removeIsForeground()
+        UserDefaultsManager.removeNotificationFeedUUID()
+        let feedDetailViewController = prepareFeedDetailViewController(feedUUID: feedUUID)
+        sinkFeedViewController(feedDetailViewController)
+        self.navigationController.pushViewController(feedDetailViewController, animated: true)
     }
 }

--- a/burstcamp/burstcamp/Scene/Tab/Home/ViewController/HomeViewController.swift
+++ b/burstcamp/burstcamp/Scene/Tab/Home/ViewController/HomeViewController.swift
@@ -207,7 +207,6 @@ extension HomeViewController: UICollectionViewDelegate, UICollectionViewDataSour
 extension HomeViewController: UNUserNotificationCenterDelegate {
     private func configurePushNotification() {
         let application = UIApplication.shared
-        UNUserNotificationCenter.current().delegate = self
 
         let authOptions: UNAuthorizationOptions = [.alert, .badge, .sound]
         UNUserNotificationCenter.current().requestAuthorization(
@@ -218,7 +217,6 @@ extension HomeViewController: UNUserNotificationCenterDelegate {
                 FirestoreUser.update(userUUID: userUUID, isPushOn: isPushOn)
             }
         }
-
         application.registerForRemoteNotifications()
     }
 }

--- a/burstcamp/burstcamp/Service/Firebase/FirestoreCollection.swift
+++ b/burstcamp/burstcamp/Service/Firebase/FirestoreCollection.swift
@@ -29,7 +29,7 @@ extension FirestoreCollection {
         case .user: return "user"
         case .scrapUser(let feedUUID): return "feed/\(feedUUID)/scrapUsers"
         case .admin: return "admin"
-        case .fcmToken: return "FCMToken"
+        case .fcmToken: return "fcmToken"
         }
     }
 

--- a/burstcamp/burstcamp/Service/FirestoreFCMToken.swift
+++ b/burstcamp/burstcamp/Service/FirestoreFCMToken.swift
@@ -16,7 +16,7 @@ struct FirebaseFCMToken {
     static func save(fcmToken: String, to userUUID: String) {
         let fcmToken = FCMToken(fcmToken: fcmToken)
         let path = fcmTokenPath.document(userUUID)
-        print("fcmToken 저장하는중", userUUID)
+        print("fcmToken 저장하는중", userUUID, fcmToken)
         guard let dictionary = fcmToken.asDictionary
         else {
             print("데이터 dictionary 변환 실패")

--- a/burstcamp/burstcamp/Service/UserDefaultsManager.swift
+++ b/burstcamp/burstcamp/Service/UserDefaultsManager.swift
@@ -11,6 +11,8 @@ struct UserDefaultsManager {
 
     private static let appearanceKey = "Appearance"
     private static let fcmTokenKey = "fcmTokenKey"
+    private static let isForegroundKey = "isForeground"
+    private static let notificationFeedUUIDKey = "notificationFeedUUIDKey"
 
     // dark mode
     static func saveAppearance(appearance: Appearance) {
@@ -33,6 +35,8 @@ struct UserDefaultsManager {
         return UserDefaults.standard.string(forKey: urlString)
     }
 
+    // TODO: 이미지 메모리 캐시 etag 정보 앱 종료시 모두 삭제 ㅇㅅㅇ..
+
     // FCMToken
     static func save(fcmToken: String) {
         UserDefaults.standard.set(fcmToken, forKey: fcmToken)
@@ -40,5 +44,31 @@ struct UserDefaultsManager {
 
     static func fcmToken() -> String? {
         return UserDefaults.standard.string(forKey: fcmTokenKey)
+    }
+
+    // isBackground
+    static func save(isForeground: String) {
+        UserDefaults.standard.set(isForeground, forKey: isForegroundKey)
+    }
+
+    static func isForeground() -> String? {
+        return UserDefaults.standard.string(forKey: isForegroundKey)
+    }
+
+    static func removeIsForeground() {
+        UserDefaults.standard.removeObject(forKey: isForegroundKey)
+    }
+
+    // notificationFeedUUID
+    static func save(notificationFeedUUID: String) {
+        UserDefaults.standard.set(notificationFeedUUID, forKey: notificationFeedUUIDKey)
+    }
+
+    static func notificationFeedUUID() -> String? {
+        return UserDefaults.standard.string(forKey: notificationFeedUUIDKey)
+    }
+
+    static func removeNotificationFeedUUID() {
+        UserDefaults.standard.removeObject(forKey: notificationFeedUUIDKey)
     }
 }

--- a/burstcamp/burstcamp/Service/UserDefaultsManager.swift
+++ b/burstcamp/burstcamp/Service/UserDefaultsManager.swift
@@ -9,9 +9,9 @@ import Foundation
 
 struct UserDefaultsManager {
 
-    private static let appearanceKey = "Appearance"
+    private static let appearanceKey = "AppearanceKey"
     private static let fcmTokenKey = "fcmTokenKey"
-    private static let isForegroundKey = "isForeground"
+    private static let isForegroundKey = "isForegroundKey"
     private static let notificationFeedUUIDKey = "notificationFeedUUIDKey"
 
     // dark mode

--- a/burstcamp/burstcamp/Service/UserDefaultsManager.swift
+++ b/burstcamp/burstcamp/Service/UserDefaultsManager.swift
@@ -47,12 +47,12 @@ struct UserDefaultsManager {
     }
 
     // isBackground
-    static func save(isForeground: String) {
+    static func save(isForeground: Bool) {
         UserDefaults.standard.set(isForeground, forKey: isForegroundKey)
     }
 
-    static func isForeground() -> String? {
-        return UserDefaults.standard.string(forKey: isForegroundKey)
+    static func isForeground() -> Bool {
+        return UserDefaults.standard.bool(forKey: isForegroundKey)
     }
 
     static func removeIsForeground() {

--- a/modules/BCResource/BCResource/Generated/Assets+Generated.swift
+++ b/modules/BCResource/BCResource/Generated/Assets+Generated.swift
@@ -44,8 +44,8 @@ public enum Assets {
     public static let yellow = ColorAsset(name: "yellow")
   }
   public enum Image {
-    public static let github = ImageAsset(name: "Github")
     public static let burstcamper100 = ImageAsset(name: "burstcamper100")
+    public static let github = ImageAsset(name: "github")
   }
 }
 // swiftlint:enable identifier_name line_length nesting type_body_length type_name


### PR DESCRIPTION
## 관련 이슈
- #211 

## 내용

<img width="1328" alt="image" src="https://user-images.githubusercontent.com/39167842/206850973-80438452-6d6e-4d64-835b-840f34c1c5cf.png">

- foreground
    - UserDefaults - isForeground && feedUUID
    - NotificationCenter .Push로 보내서 TabCoordinator에서 받습니다.
    - TabCoordinator에서 어디화면에 있든 디테일 뷰를 띄워줍니다.

- background
    - UserDefaults - feedUUID
    - HomeCoordinator가 start됐을때 isForeground false && feedUUID를 가지고 디테일 뷰를 띄워줍니다.

## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
