### PR TITLE
[캐시] etag 정보 삭제

### DIFF
--- a/burstcamp/burstcamp/App/AppDelegate.swift
+++ b/burstcamp/burstcamp/App/AppDelegate.swift
@@ -112,10 +112,10 @@ extension AppDelegate: MessagingDelegate {
 // MARK: - save user in keychain
 // TODO: https://medium.com/cashwalk/ios-background-mode-9bf921f1c55b
 extension AppDelegate {
-    func applicationWillTerminate(_ application: UIApplication) {
+    func applicationDidEnterBackground(_ application: UIApplication) {
+        UserDefaultsManager.removeIsForeground()
+        UserDefaultsManager.removeAllEtags()
         KeyChainManager.deleteUser()
-        // TODO: 삭제
-        print("앱 종료 전에 키체인에 저장될 UserManager에 있는 userUUID", UserManager.shared.user.userUUID)
         KeyChainManager.save(user: UserManager.shared.user)
     }
 }

--- a/burstcamp/burstcamp/Service/UserDefaultsManager.swift
+++ b/burstcamp/burstcamp/Service/UserDefaultsManager.swift
@@ -13,6 +13,8 @@ struct UserDefaultsManager {
     private static let fcmTokenKey = "fcmTokenKey"
     private static let isForegroundKey = "isForegroundKey"
     private static let notificationFeedUUIDKey = "notificationFeedUUIDKey"
+    
+    private static var etagKeys: [String] = []
 
     // dark mode
     static func saveAppearance(appearance: Appearance) {
@@ -28,11 +30,18 @@ struct UserDefaultsManager {
 
     // etag
     static func save(etag: String, urlString: String) {
+        etagKeys.append(etag)
         UserDefaults.standard.set(etag, forKey: urlString)
     }
 
     static func etag(urlString: String) -> String? {
         return UserDefaults.standard.string(forKey: urlString)
+    }
+    
+    static func removeAllEtags() {
+        etagKeys.forEach {
+            UserDefaults.standard.removeObject(forKey: $0)
+        }
     }
 
     // TODO: 이미지 메모리 캐시 etag 정보 앱 종료시 모두 삭제 ㅇㅅㅇ..

--- a/burstcamp/burstcamp/Util/Extension/UI/UIImageView+Cache.swift
+++ b/burstcamp/burstcamp/Util/Extension/UI/UIImageView+Cache.swift
@@ -10,9 +10,10 @@ import UIKit
 
 extension UIImageView {
 
-    func setImage(urlString: String,
-                  isDiskCaching: Bool = false,
-                  defaultImage: UIImage? = UIImage(named: "burstcamper100")
+    func setImage(
+        urlString: String,
+        isDiskCaching: Bool = false,
+        defaultImage: UIImage? = UIImage(named: "burstcamper100")
     ) {
         ImageCacheManager.shared.image(urlString: urlString, isDiskCaching: isDiskCaching)
             .map { image in image == nil ? defaultImage : image }


### PR DESCRIPTION
## 관련 이슈
<!--
이슈 번호 #000 작성  
ex) close #1 
--> 

## 내용
etag 정보들이 UserDefaults에 남아있어 메모리 캐시 특성상 앱 종료시 삭제되니 같이 삭제해주었습니다.

## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
