### PR TITLE
[에러 수정] iOS 14.0.1에서 마이페이지 클릭시 화면이 멈추고 메모리가 증가하던 에러 해결

### DIFF
--- a/burstcamp/burstcamp/Coordinator/Home/HomeCoordinator.swift
+++ b/burstcamp/burstcamp/Coordinator/Home/HomeCoordinator.swift
@@ -30,8 +30,6 @@ extension HomeCoordinator {
             return
         }
 
-        navigationController.viewControllers = [homeViewController]
-
         homeViewController.coordinatorPublisher
             .sink { [weak self] event in
                 switch event {

--- a/burstcamp/burstcamp/Coordinator/MyPage/MyPageCoordinator.swift
+++ b/burstcamp/burstcamp/Coordinator/MyPage/MyPageCoordinator.swift
@@ -77,6 +77,7 @@ extension MyPageCoordinator {
         guard let myPageViewController = viewController as? MyPageViewController else {
             return
         }
+
         prepareMyPageViewController(myPageViewController: myPageViewController)
     }
 

--- a/burstcamp/burstcamp/Coordinator/ScrapPage/ScrapPageCoordinator.swift
+++ b/burstcamp/burstcamp/Coordinator/ScrapPage/ScrapPageCoordinator.swift
@@ -28,8 +28,6 @@ extension ScrapPageCoordinator {
             return
         }
 
-        navigationController.viewControllers = [scrapPageViewController]
-
         scrapPageViewController.coordinatorPublisher
             .sink { [weak self] event in
                 switch event {

--- a/burstcamp/burstcamp/Scene/Tab/MyPage/View/MyPageView.swift
+++ b/burstcamp/burstcamp/Scene/Tab/MyPage/View/MyPageView.swift
@@ -54,7 +54,7 @@ final class MyPageView: UIView, ContainCollectionView {
 
     init() {
         super.init(frame: .zero)
-
+        configureMyPageView()
         configureCollectionView()
         configureUI()
     }
@@ -64,6 +64,9 @@ final class MyPageView: UIView, ContainCollectionView {
     }
 
     // MARK: - Methods
+    private func configureMyPageView() {
+        backgroundColor = .background
+    }
 
     private func configureUI() {
         addSubview(myPageProfileView)
@@ -95,6 +98,7 @@ final class MyPageView: UIView, ContainCollectionView {
     }
 
     private func configureCollectionView() {
+        collectionView.backgroundColor = .clear
         collectionView.isScrollEnabled = false
         let cellRegistration = UICollectionView.CellRegistration(
             handler: cellRegistrationHandler
@@ -263,6 +267,8 @@ extension MyPageView {
         SettingCell.allCases.forEach { cell in
             snapshot.appendItems([cell], toSection: cell.section)
         }
-        settingDataSource.apply(snapshot)
+        DispatchQueue.main.async {
+            self.settingDataSource.apply(snapshot, animatingDifferences: false)
+        }
     }
 }


### PR DESCRIPTION
myPageView Background color 설정
coordinator에서 필요없는 viewcontroller 설정 제거

## 관련 이슈
<!--
이슈 번호 #000 작성  
ex) close #1 
--> 
- close #225 

## 내용
<!--
로직 설명  
필요시 스크린샷 첨부
--> 
- iOS 14.0.1에서 발생하던 에러 해결
- snapshot apply -> animation `false` & DispatchQueue.main.async 에서 실행

## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 
- 이슈 확인 부탁드립니다.

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
