### PR TITLE
[알림] 디테일뷰로 가지 않는 버그 수정

### DIFF
--- a/Firebase-Functions/functions/service/apnsManager.js
+++ b/Firebase-Functions/functions/service/apnsManager.js
@@ -22,10 +22,11 @@ export async function sendNotification() {
         userUUIDs.map(userUUID => {
         return getFCMToken(userUUID)
     }))
+    const validTokens = tokens.filter(fcmToken => fcmToken != '')
 
-    logger.log('보낼 토큰들을 만들었어요', tokens)
+    logger.log('보낼 토큰들을 만들었어요', validTokens)
 
-    sendMessage(tokens, recentFeed, writer)
+    sendMessage(validTokens, recentFeed, writer)
 }
 
 

--- a/Firebase-Functions/functions/service/apnsManager.js
+++ b/Firebase-Functions/functions/service/apnsManager.js
@@ -22,7 +22,7 @@ export async function sendNotification() {
         userUUIDs.map(userUUID => {
         return getFCMToken(userUUID)
     }))
-    const validTokens = tokens.filter(fcmToken => fcmToken != '')
+    const validTokens = tokens.filter(fcmToken => fcmToken !== '')
 
     logger.log('보낼 토큰들을 만들었어요', validTokens)
 

--- a/Firebase-Functions/functions/service/firestoreManager.js
+++ b/Firebase-Functions/functions/service/firestoreManager.js
@@ -136,7 +136,11 @@ export async function getFCMToken(userUUID) {
 		.doc(userUUID)
 		.get()
 		.then((doc) => {
-			return doc.data()['fcmToken'] 
+			if (doc.exists) {
+				return doc.data()['fcmToken'] 
+			} else {
+				return ''
+			}
 		})
 }
 

--- a/burstcamp/burstcamp/Coordinator/Home/HomeCoordinator.swift
+++ b/burstcamp/burstcamp/Coordinator/Home/HomeCoordinator.swift
@@ -38,8 +38,6 @@ extension HomeCoordinator {
                 }
             }
             .store(in: &cancelBag)
-
-        checkNotificationFeed()
     }
 
     func moveToFeedDetail(feed: Feed) {
@@ -52,17 +50,5 @@ extension HomeCoordinator {
         let feedDetailViewController = prepareFeedDetailViewController(feedUUID: feedUUID)
         sinkFeedViewController(feedDetailViewController)
         self.navigationController.pushViewController(feedDetailViewController, animated: true)
-    }
-}
-
-// MARK: - handle push notification
-
-extension HomeCoordinator {
-    private func checkNotificationFeed() {
-        if !UserDefaultsManager.isForeground(),
-           let feedUUID = UserDefaultsManager.notificationFeedUUID() {
-            UserDefaultsManager.removeNotificationFeedUUID()
-            moveToFeedDetail(feedUUID: feedUUID)
-        }
     }
 }

--- a/burstcamp/burstcamp/Coordinator/TabBar/TabBarCoordinator.swift
+++ b/burstcamp/burstcamp/Coordinator/TabBar/TabBarCoordinator.swift
@@ -57,6 +57,7 @@ final class TabBarCoordinator: TabBarCoordinatorProtocol {
             tabBarController.tabBar.standardAppearance = tabBarAppearance
         }
         navigationController.viewControllers = [tabBarController]
+        checkNotificationFeed()
     }
 
     private func configureTabBarItem(of viewController: UIViewController, with page: TabBarPage) {
@@ -148,5 +149,12 @@ extension TabBarCoordinator: ContainFeedDetailCoordinator {
         let feedDetailViewController = prepareFeedDetailViewController(feedUUID: feedUUID)
         sinkFeedViewController(feedDetailViewController)
         self.navigationController.pushViewController(feedDetailViewController, animated: true)
+    }
+
+    private func checkNotificationFeed() {
+        if !UserDefaultsManager.isForeground(),
+           UserDefaultsManager.notificationFeedUUID() != nil {
+            moveToDetail()
+        }
     }
 }


### PR DESCRIPTION
## 관련 이슈
- #211 

## 내용
- 알림 백그라운드에서 탭할때 디테일뷰로 이동하지 않는 버그
- HomeCoordinator가 준비되기전에 Push해서 발생한 버그라고 생각해서 TabBarCoordinator가 모두 준비되면 디테일뷰로 이동하도록 처리했습니다.
- 기존 HomeCoordinator 처리 -> TabBarCoordinator 처리

![image](https://user-images.githubusercontent.com/39167842/207354568-85c852b4-f8c6-40bc-8187-22c7f12ebfad.png)

- 유효하지 않는 fcmToken 토큰 있을때 제외하고 알림 전송

## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
