### PR TITLE
[버그수정] 블로그 주소 마지막 "/" 처리 및 Feed 업데이트 함수 생성

### DIFF
--- a/Firebase-Functions/functions/index.js
+++ b/Firebase-Functions/functions/index.js
@@ -16,6 +16,10 @@ export const scheduledUpdateRecommendFeedDB = pubsub.schedule('every monday 00:0
 	updateRecommendFeedDB()
 })
 
+export const updateFeedDBWhenSignup = https.onCall(async (context) => {
+	updateFeedDB()
+})
+
 export const fetchBlogTitle = https.onCall(async (data, context) => {
 	const blogTitle = await getBlogTitle(data.blogURL)
 	return {

--- a/Firebase-Functions/functions/service/firestoreManager.js
+++ b/Firebase-Functions/functions/service/firestoreManager.js
@@ -99,6 +99,7 @@ async function createFeedDataIfNeeded(docRef, writerUUID, feedUUID, feed) {
  */
 export async function getFeedWriterUUID(blogURL) {
 	// https://stackoverflow.com/questions/46568142/google-firestore-query-on-substring-of-a-property-value-text-search/52715590#52715590
+	logger.log('해당 유저의 blogURL', blogURL)
 	return userRef
 		.where('blogURL', '>=', blogURL.slice(0, -1))
 		.where('blogURL', '<=', blogURL)

--- a/burstcamp/burstcamp/Scene/Auth/SignUp/Blog/SignUpBlogViewModel.swift
+++ b/burstcamp/burstcamp/Scene/Auth/SignUp/Blog/SignUpBlogViewModel.swift
@@ -101,6 +101,12 @@ final class SignUpBlogViewModel {
             throw FirebaseAuthError.fetchUUIDError
         }
 
+        var blogURL = blogURL
+        if let lastIndex = blogURL.lastIndex(of: "/"),
+           lastIndex == blogURL.index(before: blogURL.endIndex) {
+            blogURL.removeLast()
+        }
+
         return User(
             userUUID: userUUID,
             nickname: LogInManager.shared.nickname,

--- a/burstcamp/burstcamp/Scene/Common/View/DefaultBadgeView.swift
+++ b/burstcamp/burstcamp/Scene/Common/View/DefaultBadgeView.swift
@@ -55,6 +55,7 @@ final class DefaultBadgeView: UIView {
 extension DefaultBadgeView {
     func updateView(user: User) {
         domainLabel.updateView(text: user.domain.rawValue)
+        domainLabel.textColor = user.domain.color
         let number = "\(user.ordinalNumber)기"
         numberLabel.updateView(text: number)
         camperIDLabel.updateView(text: user.camperID)
@@ -62,6 +63,7 @@ extension DefaultBadgeView {
 
     func updateView(feedWriter: FeedWriter) {
         domainLabel.updateView(text: feedWriter.domain.rawValue)
+        domainLabel.textColor = feedWriter.domain.color
         let number = "\(feedWriter.ordinalNumber)기"
         numberLabel.updateView(text: number)
         camperIDLabel.updateView(text: feedWriter.camperID)

--- a/burstcamp/burstcamp/Util/Constant/URLRegularExpression.swift
+++ b/burstcamp/burstcamp/Util/Constant/URLRegularExpression.swift
@@ -8,6 +8,6 @@
 import Foundation
 
 enum URLRegularExpression {
-    static let tistory = #"^https://?[a-z0-9-]{4,32}.tistory.com$"#
+    static let tistory = #"^https://?[a-z0-9-]{4,32}.tistory.com[/]{0,1}$"#
     static let velog = #"^https://velog.io/@?[A-Za-z0-9-_]{3,16}$"#
 }


### PR DESCRIPTION
## 관련 이슈
- #241 

## 내용
- 회원가입시 추가한 블로그 주소를 포함하여 Feed DB 업데이트하기 위한 FeedDB 업데이트 함수 `updateFeedDBWhenSignup` Functions 생성
- 회원가입시 블로그 입력받을 때 마지막 "/" 포함 가능하도록 변경
- "/" 포함시 DB에는 삭제 후 저장

## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
