### PR TITLE
[캐시] 네트워크 요청 전 로컬 캐시 이미지 반환

### DIFF
--- a/burstcamp/burstcamp/Scene/Tab/MyPage/View/MyPageEditView.swift
+++ b/burstcamp/burstcamp/Scene/Tab/MyPage/View/MyPageEditView.swift
@@ -133,7 +133,7 @@ final class MyPageEditView: UIView {
     }
 
     func updateCurrentUserInfo(user: User) {
-        profileImageView.setImage(urlString: user.profileImageURL)
+        profileImageView.setImage(urlString: user.profileImageURL, isDiskCaching: true)
         nickNameTextField.text = user.nickname
         blogLinkTextField.text = user.blogURL
         blogTitleImageLabel = DefaultImageLabel(

--- a/burstcamp/burstcamp/Service/ImageCacheManager.swift
+++ b/burstcamp/burstcamp/Service/ImageCacheManager.swift
@@ -210,7 +210,9 @@ final class ImageCacheManager: NSObject, NSCacheDelegate {
         switch max {
         case 0...300: return max
         case 301...600: return ImageCacheManager.thumnailMaxPixel
-        default: return max / 2
+        case 601...1000: return max / 2
+        case 1001...1500: return max / 3
+        default: return max / 4
         }
     }
 }

--- a/burstcamp/burstcamp/Service/ImageCacheManager.swift
+++ b/burstcamp/burstcamp/Service/ImageCacheManager.swift
@@ -39,30 +39,36 @@ final class ImageCacheManager: NSObject, NSCacheDelegate {
 
     func image(
         urlString: String,
-        isDiskCaching: Bool
-    ) -> AnyPublisher<UIImage?, Never> {
+        isDiskCaching: Bool,
+        imagePublisher: PassthroughSubject<UIImage?, Never>
+    ) {
         // 1. memory cache
         if let image = memoryCachedImage(urlString: urlString) {
+            imagePublisher.send(image)
+
             let etag = UserDefaultsManager.etag(urlString: urlString)
-            return request(urlString: urlString, etag: etag, isDisk: isDiskCaching)
+            request(urlString: urlString, etag: etag, isDisk: isDiskCaching)
                 .catch { _ in Just(image) }
-                .eraseToAnyPublisher()
+                .sink { image in imagePublisher.send(image) }
+                .store(in: &cancelBag)
         }
 
         // 2. disk cache
         if isDiskCaching, let image = diskCachedImage(urlString: urlString) {
+            imagePublisher.send(image)
+
             let etag = UserDefaultsManager.etag(urlString: urlString)
-            return request(urlString: urlString, etag: etag, isDisk: isDiskCaching)
+            request(urlString: urlString, etag: etag, isDisk: isDiskCaching)
                 .catch { _ in Just(image) }
-                .eraseToAnyPublisher()
+                .sink { image in imagePublisher.send(image) }
+                .store(in: &cancelBag)
         }
 
         // 3. network request
-        return request(urlString: urlString, etag: nil, isDisk: isDiskCaching)
-            .catch { _ in
-                Just(nil)
-            }
-            .eraseToAnyPublisher()
+        request(urlString: urlString, etag: nil, isDisk: isDiskCaching)
+            .catch { _ in Just(nil) }
+            .sink { image in imagePublisher.send(image) }
+            .store(in: &cancelBag)
     }
 
     // MARK: Memory

--- a/burstcamp/burstcamp/Util/Extension/UI/UIImageView+Cache.swift
+++ b/burstcamp/burstcamp/Util/Extension/UI/UIImageView+Cache.swift
@@ -28,9 +28,5 @@ extension UIImageView {
             isDiskCaching: isDiskCaching,
             imagePublisher: imagePublisher
         )
-//            .map { image in image == nil ? defaultImage : image }
-//            .receive(on: DispatchQueue.main)
-//            .assign(to: \.image, on: self)
-//            .store(in: &ImageCacheManager.shared.cancelBag)
     }
 }

--- a/burstcamp/burstcamp/Util/Extension/UI/UIImageView+Cache.swift
+++ b/burstcamp/burstcamp/Util/Extension/UI/UIImageView+Cache.swift
@@ -13,12 +13,24 @@ extension UIImageView {
     func setImage(
         urlString: String,
         isDiskCaching: Bool = false,
-        defaultImage: UIImage? = UIImage(named: "burstcamper100")
+        defaultImage: UIImage? = UIImage(named: "burstcamper100"),
+        imagePublisher: PassthroughSubject<UIImage?, Never> =
+        PassthroughSubject<UIImage?, Never>()
     ) {
-        ImageCacheManager.shared.image(urlString: urlString, isDiskCaching: isDiskCaching)
+        imagePublisher
             .map { image in image == nil ? defaultImage : image }
             .receive(on: DispatchQueue.main)
             .assign(to: \.image, on: self)
             .store(in: &ImageCacheManager.shared.cancelBag)
+
+        ImageCacheManager.shared.image(
+            urlString: urlString,
+            isDiskCaching: isDiskCaching,
+            imagePublisher: imagePublisher
+        )
+//            .map { image in image == nil ? defaultImage : image }
+//            .receive(on: DispatchQueue.main)
+//            .assign(to: \.image, on: self)
+//            .store(in: &ImageCacheManager.shared.cancelBag)
     }
 }


### PR DESCRIPTION
## 관련 이슈
- #31 

## 내용
이미지의 etag를 확인하는 과정에서 네트워크 요청을 기다리기 전에 로컬 캐시가 있다면 우선 반환하도록 코드를 수정했습니다.

고쳐야 할 것은 cancelBag이 ImageCacheManager것을 가져다 써서 cancel이 일어나지 않는다는 에러사항이 있습니다..


## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
