### PR TITLE
[푸시알림] 백그라운드 이동 버그 수정

### DIFF
--- a/burstcamp/burstcamp/Coordinator/TabBar/TabBarCoordinator.swift
+++ b/burstcamp/burstcamp/Coordinator/TabBar/TabBarCoordinator.swift
@@ -38,6 +38,7 @@ final class TabBarCoordinator: TabBarCoordinatorProtocol {
             .map { prepareTabController($0) }
 
         configureTabBarController(with: controllers)
+        checkNotification()
     }
 
     func selectPage(_ page: TabBarPage) {
@@ -57,7 +58,6 @@ final class TabBarCoordinator: TabBarCoordinatorProtocol {
             tabBarController.tabBar.standardAppearance = tabBarAppearance
         }
         navigationController.viewControllers = [tabBarController]
-        checkNotificationFeed()
     }
 
     private func configureTabBarItem(of viewController: UIViewController, with page: TabBarPage) {
@@ -142,18 +142,25 @@ extension TabBarCoordinator: ContainFeedDetailCoordinator {
         )
     }
 
-    @objc func moveToDetail() {
-        guard let feedUUID = UserDefaultsManager.notificationFeedUUID() else { return }
-        UserDefaultsManager.removeIsForeground()
+    @objc func moveToDetail(_ notification: Notification) {
+        guard let feedUUID = notification.userInfo?[NotificationKey.feedUUID] as? String
+        else { return }
         UserDefaultsManager.removeNotificationFeedUUID()
         let feedDetailViewController = prepareFeedDetailViewController(feedUUID: feedUUID)
         sinkFeedViewController(feedDetailViewController)
         self.navigationController.pushViewController(feedDetailViewController, animated: true)
     }
 
-    private func checkNotificationFeed() {
-        if UserDefaultsManager.notificationFeedUUID() != nil {
-            moveToDetail()
+    private func checkNotification() {
+        if let feedUUID = UserDefaultsManager.notificationFeedUUID() {
+            UserDefaultsManager.removeNotificationFeedUUID()
+            moveToFeedDetail(feedUUID: feedUUID)
         }
+    }
+
+    private func moveToFeedDetail(feedUUID: String) {
+        let feedDetailViewController = prepareFeedDetailViewController(feedUUID: feedUUID)
+        sinkFeedViewController(feedDetailViewController)
+        self.navigationController.pushViewController(feedDetailViewController, animated: true)
     }
 }

--- a/burstcamp/burstcamp/Coordinator/TabBar/TabBarCoordinator.swift
+++ b/burstcamp/burstcamp/Coordinator/TabBar/TabBarCoordinator.swift
@@ -152,8 +152,7 @@ extension TabBarCoordinator: ContainFeedDetailCoordinator {
     }
 
     private func checkNotificationFeed() {
-        if !UserDefaultsManager.isForeground(),
-           UserDefaultsManager.notificationFeedUUID() != nil {
+        if UserDefaultsManager.notificationFeedUUID() != nil {
             moveToDetail()
         }
     }

--- a/burstcamp/burstcamp/Coordinator/TabBar/TabBarCoordinator.swift
+++ b/burstcamp/burstcamp/Coordinator/TabBar/TabBarCoordinator.swift
@@ -38,7 +38,7 @@ final class TabBarCoordinator: TabBarCoordinatorProtocol {
             .map { prepareTabController($0) }
 
         configureTabBarController(with: controllers)
-        checkNotification()
+        moveToFeedDetail()
     }
 
     func selectPage(_ page: TabBarPage) {
@@ -136,31 +136,18 @@ extension TabBarCoordinator: ContainFeedDetailCoordinator {
     private func addObserver() {
         NotificationCenter.default.addObserver(
             self,
-            selector: #selector(moveToDetail),
+            selector: #selector(moveToFeedDetail),
             name: .Push,
             object: nil
         )
     }
 
-    @objc func moveToDetail(_ notification: Notification) {
-        guard let feedUUID = notification.userInfo?[NotificationKey.feedUUID] as? String
-        else { return }
-        UserDefaultsManager.removeNotificationFeedUUID()
-        let feedDetailViewController = prepareFeedDetailViewController(feedUUID: feedUUID)
-        sinkFeedViewController(feedDetailViewController)
-        self.navigationController.pushViewController(feedDetailViewController, animated: true)
-    }
-
-    private func checkNotification() {
+    @objc func moveToFeedDetail() {
         if let feedUUID = UserDefaultsManager.notificationFeedUUID() {
             UserDefaultsManager.removeNotificationFeedUUID()
-            moveToFeedDetail(feedUUID: feedUUID)
+            let feedDetailViewController = prepareFeedDetailViewController(feedUUID: feedUUID)
+            sinkFeedViewController(feedDetailViewController)
+            navigationController.pushViewController(feedDetailViewController, animated: true)
         }
-    }
-
-    private func moveToFeedDetail(feedUUID: String) {
-        let feedDetailViewController = prepareFeedDetailViewController(feedUUID: feedUUID)
-        sinkFeedViewController(feedDetailViewController)
-        self.navigationController.pushViewController(feedDetailViewController, animated: true)
     }
 }

--- a/burstcamp/burstcamp/Service/UserDefaultsManager.swift
+++ b/burstcamp/burstcamp/Service/UserDefaultsManager.swift
@@ -55,19 +55,6 @@ struct UserDefaultsManager {
         return UserDefaults.standard.string(forKey: fcmTokenKey)
     }
 
-    // isBackground
-    static func save(isForeground: Bool) {
-        UserDefaults.standard.set(isForeground, forKey: isForegroundKey)
-    }
-
-    static func isForeground() -> Bool {
-        return UserDefaults.standard.bool(forKey: isForegroundKey)
-    }
-
-    static func removeIsForeground() {
-        UserDefaults.standard.removeObject(forKey: isForegroundKey)
-    }
-
     // notificationFeedUUID
     static func save(notificationFeedUUID: String) {
         UserDefaults.standard.set(notificationFeedUUID, forKey: notificationFeedUUIDKey)


### PR DESCRIPTION
## 관련 이슈
- #211 

## 내용
알림 클릭시 => UserDefaults에 feedUUID 저장

- Suspended 알림받기 + Suspended 실행 => (app 코디네이터 start 후) UserDefaults feedUUID 확인, UserDefaults 삭제

- Suspended 알림받기 + foreground 실행 => (app 코디네이터 start 후) UserDefaults feedUUID 확인, UserDefaults 삭제

- background 알림받기 + background 실행 => (app 코디네이터 살아있음) NotificationCenter, UserDefaults 삭제

- background 알림받기 + foreground 실행 => (app 코디네이터 살아있음) NotificationCenter, UserDefaults 삭제

## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
