### PR TITLE
Feature/284 feat feeddetail에서 스크랩 시 home에도 적용

### DIFF
--- a/burstcamp/burstcamp.xcodeproj/project.pbxproj
+++ b/burstcamp/burstcamp.xcodeproj/project.pbxproj
@@ -92,6 +92,7 @@
 		14D8C4B6297B7E6300DFE71F /* Updater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14D8C4B5297B7E6300DFE71F /* Updater.swift */; };
 		14D8C4BD297BCC3B00DFE71F /* ScrapFeedAPIModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14D8C4BC297BCC3B00DFE71F /* ScrapFeedAPIModel.swift */; };
 		14D8C4C6297BEDB900DFE71F /* HomeViewModelError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14D8C4C5297BEDB900DFE71F /* HomeViewModelError.swift */; };
+		14D8C4D4297C0C0200DFE71F /* FeedDetailViewModelError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14D8C4D3297C0C0200DFE71F /* FeedDetailViewModelError.swift */; };
 		14F94BE62939E16D0058A79A /* UICollectionView+emptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F94BE52939E16D0058A79A /* UICollectionView+emptyView.swift */; };
 		3B061FD82928CC5600BFA71D /* SignUpDomainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B061FD72928CC5600BFA71D /* SignUpDomainViewController.swift */; };
 		3B061FDA2928CF7E00BFA71D /* SighUpDomainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B061FD92928CF7E00BFA71D /* SighUpDomainView.swift */; };
@@ -340,6 +341,7 @@
 		14D8C4B5297B7E6300DFE71F /* Updater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Updater.swift; sourceTree = "<group>"; };
 		14D8C4BC297BCC3B00DFE71F /* ScrapFeedAPIModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrapFeedAPIModel.swift; sourceTree = "<group>"; };
 		14D8C4C5297BEDB900DFE71F /* HomeViewModelError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModelError.swift; sourceTree = "<group>"; };
+		14D8C4D3297C0C0200DFE71F /* FeedDetailViewModelError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedDetailViewModelError.swift; sourceTree = "<group>"; };
 		14F94BE52939E16D0058A79A /* UICollectionView+emptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionView+emptyView.swift"; sourceTree = "<group>"; };
 		3B061FD72928CC5600BFA71D /* SignUpDomainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpDomainViewController.swift; sourceTree = "<group>"; };
 		3B061FD92928CF7E00BFA71D /* SighUpDomainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SighUpDomainView.swift; sourceTree = "<group>"; };
@@ -579,6 +581,7 @@
 			isa = PBXGroup;
 			children = (
 				140FBEE429750D0B006B7857 /* LoginViewModelError.swift */,
+				14D8C4D3297C0C0200DFE71F /* FeedDetailViewModelError.swift */,
 				14D8C4C5297BEDB900DFE71F /* HomeViewModelError.swift */,
 				140FBEF329756A3D006B7857 /* SignUpBlogViewModelError.swift */,
 			);
@@ -1955,6 +1958,7 @@
 				B5DAD67B292E4C6800C4A126 /* FeedDetailViewController.swift in Sources */,
 				D84452EC292CA55F008E811B /* MyPageEditView.swift in Sources */,
 				140E210429443E6300D6E2E5 /* FirestoreService.swift in Sources */,
+				14D8C4D4297C0C0200DFE71F /* FeedDetailViewModelError.swift in Sources */,
 				D89E48B12939D9AC00744A56 /* FireStorageError.swift in Sources */,
 				D8494D522927D086008157F1 /* MyPageProfileView.swift in Sources */,
 				148A055B2972F77C00664CCB /* DefaultHomeUseCase.swift in Sources */,

--- a/burstcamp/burstcamp.xcodeproj/project.pbxproj
+++ b/burstcamp/burstcamp.xcodeproj/project.pbxproj
@@ -93,6 +93,7 @@
 		14D8C4BD297BCC3B00DFE71F /* ScrapFeedAPIModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14D8C4BC297BCC3B00DFE71F /* ScrapFeedAPIModel.swift */; };
 		14D8C4C6297BEDB900DFE71F /* HomeViewModelError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14D8C4C5297BEDB900DFE71F /* HomeViewModelError.swift */; };
 		14D8C4D4297C0C0200DFE71F /* FeedDetailViewModelError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14D8C4D3297C0C0200DFE71F /* FeedDetailViewModelError.swift */; };
+		14D8C4D6297C103800DFE71F /* ContainFeedDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14D8C4D5297C103800DFE71F /* ContainFeedDetailViewController.swift */; };
 		14F94BE62939E16D0058A79A /* UICollectionView+emptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F94BE52939E16D0058A79A /* UICollectionView+emptyView.swift */; };
 		3B061FD82928CC5600BFA71D /* SignUpDomainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B061FD72928CC5600BFA71D /* SignUpDomainViewController.swift */; };
 		3B061FDA2928CF7E00BFA71D /* SighUpDomainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B061FD92928CF7E00BFA71D /* SighUpDomainView.swift */; };
@@ -342,6 +343,7 @@
 		14D8C4BC297BCC3B00DFE71F /* ScrapFeedAPIModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrapFeedAPIModel.swift; sourceTree = "<group>"; };
 		14D8C4C5297BEDB900DFE71F /* HomeViewModelError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModelError.swift; sourceTree = "<group>"; };
 		14D8C4D3297C0C0200DFE71F /* FeedDetailViewModelError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedDetailViewModelError.swift; sourceTree = "<group>"; };
+		14D8C4D5297C103800DFE71F /* ContainFeedDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainFeedDetailViewController.swift; sourceTree = "<group>"; };
 		14F94BE52939E16D0058A79A /* UICollectionView+emptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionView+emptyView.swift"; sourceTree = "<group>"; };
 		3B061FD72928CC5600BFA71D /* SignUpDomainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpDomainViewController.swift; sourceTree = "<group>"; };
 		3B061FD92928CF7E00BFA71D /* SighUpDomainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SighUpDomainView.swift; sourceTree = "<group>"; };
@@ -1342,6 +1344,7 @@
 			children = (
 				B50A279729279F5D00DF3E1F /* ReusableView.swift */,
 				143185F7292B5C88008CE459 /* ContainCollectionView.swift */,
+				14D8C4D5297C103800DFE71F /* ContainFeedDetailViewController.swift */,
 			);
 			path = Protocol;
 			sourceTree = "<group>";
@@ -1895,6 +1898,7 @@
 				B572EFA129479D1500A9413C /* FeedRealmModel.swift in Sources */,
 				D8E979CA293A6D430092EBF6 /* Alert.swift in Sources */,
 				140438BB293F6FD7004D035C /* HomeCoordinator.swift in Sources */,
+				14D8C4D6297C103800DFE71F /* ContainFeedDetailViewController.swift in Sources */,
 				B50A27E429279F5D00DF3E1F /* GithubLoginModel.swift in Sources */,
 				B50A27ED29279F5D00DF3E1F /* NormalFeedCell.swift in Sources */,
 				14F94BE62939E16D0058A79A /* UICollectionView+emptyView.swift in Sources */,

--- a/burstcamp/burstcamp/Domain/UseCase/Tab/Detail/DefaultFeedDetailUseCase.swift
+++ b/burstcamp/burstcamp/Domain/UseCase/Tab/Detail/DefaultFeedDetailUseCase.swift
@@ -8,4 +8,16 @@
 import Foundation
 
 final class DefaultFeedDetailUseCase: FeedDetailUseCase {
+    
+    private let feedRepository: FeedRepository
+    
+    init(feedRepository: FeedRepository) {
+        self.feedRepository = feedRepository
+    }
+    
+    func scrapFeed(_ feed: Feed, userUUID: String) async throws -> Feed {
+        return feed.isScraped
+        ? try await feedRepository.unScrapFeed(feed, userUUID: userUUID)
+        : try await feedRepository.scrapFeed(feed, userUUID: userUUID)
+    }
 }

--- a/burstcamp/burstcamp/Domain/UseCase/Tab/Detail/DefaultFeedDetailUseCase.swift
+++ b/burstcamp/burstcamp/Domain/UseCase/Tab/Detail/DefaultFeedDetailUseCase.swift
@@ -8,13 +8,13 @@
 import Foundation
 
 final class DefaultFeedDetailUseCase: FeedDetailUseCase {
-    
+
     private let feedRepository: FeedRepository
-    
+
     init(feedRepository: FeedRepository) {
         self.feedRepository = feedRepository
     }
-    
+
     func scrapFeed(_ feed: Feed, userUUID: String) async throws -> Feed {
         return feed.isScraped
         ? try await feedRepository.unScrapFeed(feed, userUUID: userUUID)

--- a/burstcamp/burstcamp/Domain/UseCase/Tab/Detail/FeedDetailUseCase.swift
+++ b/burstcamp/burstcamp/Domain/UseCase/Tab/Detail/FeedDetailUseCase.swift
@@ -8,4 +8,5 @@
 import Foundation
 
 protocol FeedDetailUseCase {
+    func scrapFeed(_ feed: Feed, userUUID: String) async throws -> Feed
 }

--- a/burstcamp/burstcamp/Presentation/Coordinator/Base/ContainFeedDetailCoordinator.swift
+++ b/burstcamp/burstcamp/Presentation/Coordinator/Base/ContainFeedDetailCoordinator.swift
@@ -29,9 +29,18 @@ extension ContainFeedDetailCoordinator {
             .store(in: &cancelBag)
     }
 
-    func sink(_ feedDetailViewController: FeedDetailViewController, homeViewController: HomeViewController) {
+    func sink(_ feedDetailViewController: FeedDetailViewController, parentViewController: ContainFeedDetailViewController) {
+        feedDetailViewController.coordinatorPublisher
+            .sink { [weak self] event in
+                switch event {
+                case .moveToBlogSafari(let url):
+                    self?.moveToBlogSafari(url: url)
+                }
+            }
+            .store(in: &cancelBag)
+
         let updateFeedPublisher = feedDetailViewController.getUpdateFeedPublisher()
-        homeViewController.configure(scrapUpdatePublisher: updateFeedPublisher)
+        parentViewController.configure(scrapUpdatePublisher: updateFeedPublisher)
     }
 
     func prepareFeedDetailViewController(feed: Feed) -> FeedDetailViewController {

--- a/burstcamp/burstcamp/Presentation/Coordinator/Base/ContainFeedDetailCoordinator.swift
+++ b/burstcamp/burstcamp/Presentation/Coordinator/Base/ContainFeedDetailCoordinator.swift
@@ -36,24 +36,16 @@ extension ContainFeedDetailCoordinator {
 
     func prepareFeedDetailViewController(feed: Feed) -> FeedDetailViewController {
         let feedDetailViewModel = dependencyFactory.createFeedDetailViewModel(feed: feed)
-        let scrapViewModel = ScrapViewModel(
-            feedUUID: feed.feedUUID
-        )
         let feedDetailViewController = FeedDetailViewController(
-            feedDetailViewModel: feedDetailViewModel,
-            scrapViewModel: scrapViewModel
+            feedDetailViewModel: feedDetailViewModel
         )
         return feedDetailViewController
     }
 
     func prepareFeedDetailViewController(feedUUID: String) -> FeedDetailViewController {
         let feedDetailViewModel = dependencyFactory.createFeedDetailViewModel(feedUUID: feedUUID)
-        let scrapViewModel = ScrapViewModel(
-            feedUUID: feedUUID
-        )
         let feedDetailViewController = FeedDetailViewController(
-            feedDetailViewModel: feedDetailViewModel,
-            scrapViewModel: scrapViewModel
+            feedDetailViewModel: feedDetailViewModel
         )
         return feedDetailViewController
     }

--- a/burstcamp/burstcamp/Presentation/Coordinator/Home/HomeCoordinator.swift
+++ b/burstcamp/burstcamp/Presentation/Coordinator/Home/HomeCoordinator.swift
@@ -9,7 +9,7 @@ import Combine
 import UIKit
 
 protocol HomeCoordinatorProtocol: TabBarChildCoordinator {
-//    func moveToFeedDetail(feed: Feed)
+    func moveToFeedDetail(feed: Feed, homeViewController: HomeViewController)
     func moveToFeedDetail(feedUUID: String)
     func moveToBlogSafari(url: URL)
 }
@@ -44,8 +44,7 @@ extension HomeCoordinator {
 
     func moveToFeedDetail(feed: Feed, homeViewController: HomeViewController) {
         let feedDetailViewController = prepareFeedDetailViewController(feed: feed)
-        sinkFeedViewController(feedDetailViewController)
-        sink(feedDetailViewController, homeViewController: homeViewController)
+        sink(feedDetailViewController, parentViewController: homeViewController)
         self.navigationController.pushViewController(feedDetailViewController, animated: true)
     }
 

--- a/burstcamp/burstcamp/Presentation/Factory/DependencyFactory.swift
+++ b/burstcamp/burstcamp/Presentation/Factory/DependencyFactory.swift
@@ -106,12 +106,14 @@ extension DependencyFactory {
     }
 
     func createFeedDetailViewModel(feed: Feed) -> FeedDetailViewModel {
-        let feedDetailUseCase = DefaultFeedDetailUseCase()
+        let feedRepository = DefaultFeedRepository(bcFirestoreService: BCFirestoreService())
+        let feedDetailUseCase = DefaultFeedDetailUseCase(feedRepository: feedRepository)
         return FeedDetailViewModel(feedDetailUseCase: feedDetailUseCase, feed: feed)
     }
 
     func createFeedDetailViewModel(feedUUID: String) -> FeedDetailViewModel {
-        let feedDetailUseCase = DefaultFeedDetailUseCase()
+        let feedRepository = DefaultFeedRepository(bcFirestoreService: BCFirestoreService())
+        let feedDetailUseCase = DefaultFeedDetailUseCase(feedRepository: feedRepository)
         return FeedDetailViewModel(feedDetailUseCase: feedDetailUseCase, feedUUID: feedUUID)
     }
 

--- a/burstcamp/burstcamp/Presentation/Tab/Detail/ViewController/FeedDetailViewController.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/Detail/ViewController/FeedDetailViewController.swift
@@ -41,18 +41,15 @@ final class FeedDetailViewController: UIViewController {
     private lazy var shareBarButtonItem = UIBarButtonItem(customView: shareButton)
 
     private let feedDetailViewModel: FeedDetailViewModel
-    private let scrapViewModel: ScrapViewModel
 
     let coordinatorPublisher = PassthroughSubject<FeedDetailCoordinatorEvent, Never>()
     private var updateFeedPublisher = PassthroughSubject<Feed, Never>()
     private var cancelBag = Set<AnyCancellable>()
 
     init(
-        feedDetailViewModel: FeedDetailViewModel,
-        scrapViewModel: ScrapViewModel
+        feedDetailViewModel: FeedDetailViewModel
     ) {
         self.feedDetailViewModel = feedDetailViewModel
-        self.scrapViewModel = scrapViewModel
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -99,6 +96,7 @@ final class FeedDetailViewController: UIViewController {
         feedDetailOutput.feedDidUpdate
             .receive(on: DispatchQueue.main)
             .sink { [weak self] feed in
+                self?.scrapButton.isOn = feed.isScraped
                 self?.feedDetailView.configure(with: feed)
             }
             .store(in: &cancelBag)

--- a/burstcamp/burstcamp/Presentation/Tab/Detail/ViewModel/FeedDetailViewModel.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/Detail/ViewModel/FeedDetailViewModel.swift
@@ -11,7 +11,8 @@ import Foundation
 final class FeedDetailViewModel {
 
     private let feedDetailUseCase: FeedDetailUseCase
-    private let feed = CurrentValueSubject<Feed?, Never>(nil)
+    private let feedPublisher = CurrentValueSubject<Feed?, Never>(nil)
+    private let scrapPublisher = CurrentValueSubject<Feed?, Never>(nil)
     private var cancelBag = Set<AnyCancellable>()
 
     init(feedDetailUseCase: FeedDetailUseCase) {
@@ -20,7 +21,7 @@ final class FeedDetailViewModel {
 
     convenience init(feedDetailUseCase: FeedDetailUseCase, feed: Feed) {
         self.init(feedDetailUseCase: feedDetailUseCase)
-        self.feed.send(feed)
+        self.feedPublisher.send(feed)
     }
 
     /// DeepLink를 통해서 진입할 때 호출하는 initializer
@@ -28,43 +29,52 @@ final class FeedDetailViewModel {
         self.init(feedDetailUseCase: feedDetailUseCase)
         // TODO: Cache에 데이터가 없을 수 있기 때문에 Remote에서 불러와야 한다.
         let feed = FeedRealmDataSource.shared.cachedNormalFeed(feedUUID: feedUUID)
-        self.feed.send(feed)
+        self.feedPublisher.send(feed)
     }
 
     struct Input {
         let viewDidLoad: AnyPublisher<Void, Never>
         let blogButtonDidTap: AnyPublisher<Void, Never>
         let shareButtonDidTap: AnyPublisher<Void, Never>
+        let scrapButtonDidTap: AnyPublisher<Void, Never>
     }
 
     struct Output {
         let feedDidUpdate: AnyPublisher<Feed, Never>
         let openBlog: AnyPublisher<URL, Never>
         let openActivityView: AnyPublisher<String, Never>
+        let scrapUpdate: AnyPublisher<Feed, Never>
     }
 
     func transform(input: Input) -> Output {
+        input.scrapButtonDidTap
+            .sink { [weak self] _ in
+                self?.scrapPublisher.send(nil)
+            }
+            .store(in: &cancelBag)
+
         let openBlog = input.blogButtonDidTap
             .compactMap { [weak self] in
-                self?.feed.value?.url
+                self?.feedPublisher.value?.url
             }
             .compactMap { URL(string: $0) }
             .eraseToAnyPublisher()
 
         let openActivityView = input.shareButtonDidTap
             .compactMap { [weak self] in
-                self?.feed.value?.url
+                self?.feedPublisher.value?.url
             }
             .eraseToAnyPublisher()
 
         return Output(
-            feedDidUpdate: feed.unwrap().eraseToAnyPublisher(),
+            feedDidUpdate: feedPublisher.unwrap().eraseToAnyPublisher(),
             openBlog: openBlog,
-            openActivityView: openActivityView
+            openActivityView: openActivityView,
+            scrapUpdate: scrapPublisher.unwrap().eraseToAnyPublisher()
         )
     }
 
     func getFeed() -> Feed? {
-        return feed.value
+        return feedPublisher.value
     }
 }

--- a/burstcamp/burstcamp/Presentation/Tab/Home/ViewController/HomeViewController.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/Home/ViewController/HomeViewController.swift
@@ -126,6 +126,7 @@ final class HomeViewController: UIViewController {
 
         let scrapButtonDidTap = cell.getButtonTapPublisher()
             .map { _  in
+                cell.footerView.scrapButton.isEnabled = false
                 return index
             }
             .eraseToAnyPublisher()

--- a/burstcamp/burstcamp/Presentation/Tab/Home/ViewController/HomeViewController.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/Home/ViewController/HomeViewController.swift
@@ -305,7 +305,7 @@ extension HomeViewController: UNUserNotificationCenterDelegate {
     }
 }
 
-extension HomeViewController {
+extension HomeViewController: ContainFeedDetailViewController {
     func configure(scrapUpdatePublisher: AnyPublisher<Feed, Never>) {
         scrapUpdatePublisher
             .sink { [weak self] feed in

--- a/burstcamp/burstcamp/Presentation/Tab/Home/ViewController/HomeViewController.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/Home/ViewController/HomeViewController.swift
@@ -309,8 +309,7 @@ extension HomeViewController {
     func configure(scrapUpdatePublisher: AnyPublisher<Feed, Never>) {
         scrapUpdatePublisher
             .sink { [weak self] feed in
-                // TODO: Feed Detail에서 스크랩 이후 refresh 안해도 되면 제거
-//                self?.reloadNormalFeedSection()
+                self?.reloadNormalFeedSection()
                 self?.viewModel.updateNormalFeed(feed)
             }
             .store(in: &cancelBag)

--- a/burstcamp/burstcamp/Util/Error/ViewModel/FeedDetailViewModelError.swift
+++ b/burstcamp/burstcamp/Util/Error/ViewModel/FeedDetailViewModelError.swift
@@ -1,0 +1,20 @@
+//
+//  FeedDetailViewModel.swift
+//  burstcamp
+//
+//  Created by youtak on 2023/01/21.
+//
+
+import Foundation
+
+enum FeedDetailViewModelError: LocalizedError {
+    case feedIsNil
+}
+
+extension FeedDetailViewModelError {
+    var errorDescription: String? {
+        switch self {
+        case .feedIsNil: return "해당하는 Feed가 없습니다."
+        }
+    }
+}

--- a/burstcamp/burstcamp/Util/Protocol/ContainFeedDetailViewController.swift
+++ b/burstcamp/burstcamp/Util/Protocol/ContainFeedDetailViewController.swift
@@ -1,0 +1,13 @@
+//
+//  ContainFeedDetailViewController.swift
+//  burstcamp
+//
+//  Created by youtak on 2023/01/21.
+//
+
+import Combine
+import Foundation
+
+protocol ContainFeedDetailViewController {
+    func configure(scrapUpdatePublisher: AnyPublisher<Feed, Never>)
+}


### PR DESCRIPTION
## 관련 이슈
<!--
이슈 번호 #000 작성  
ex) close #1 
--> 
- close #284 

## 내용
<!--
로직 설명  
필요시 스크린샷 첨부
--> 
- FeedDetail에서 스크랩
  - ScrapViewModel 제거
  - 스크랩 완료시 ContainFeedDetailViewController 프로토콜을 채택한 ViewController에게 업데이트 된 피드를 전달함. 현재는 HomeViewController만 채택하고 있어, Home -> FeedDetail 플로우에서 스크랩/스크랩 해제시 HomeView도 업데이트 함
  - FeedDetail 들어갈 때 스크랩 여부 체크

### Home -> FeedDetail -> 스크랩 -> pop -> 홈 업데이트

https://user-images.githubusercontent.com/71776532/213866884-acee4536-2316-440e-9950-31e94ce07da3.mp4

### Home -> FeedDetail -> 언 스크랩 -> pop -> 홈 업데이트

https://user-images.githubusercontent.com/71776532/213866887-84cc0fe2-eedd-47c4-a8a0-daf574718b72.mp4


## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
