### PR TITLE
[Feature]scrappage usecase 구현

### DIFF
--- a/burstcamp/burstcamp.xcodeproj/project.pbxproj
+++ b/burstcamp/burstcamp.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		141344D9292F803800187B86 /* UIControl+Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 141344D8292F803800187B86 /* UIControl+Combine.swift */; };
 		141344DB292F82BE00187B86 /* Feed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 141344DA292F82BE00187B86 /* Feed.swift */; };
 		1418960229377593005A42D4 /* UIScrollView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1418960129377593005A42D4 /* UIScrollView+.swift */; };
+		141A7A70297E5BDC003DD926 /* ScrapViewModelError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 141A7A6F297E5BDC003DD926 /* ScrapViewModelError.swift */; };
 		1422C62F292F08BC00337710 /* BCDateFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1422C62E292F08BC00337710 /* BCDateFormatter.swift */; };
 		143185E8292B46F9008CE459 /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 143185E7292B46F9008CE459 /* HomeViewModel.swift */; };
 		143185EA292B4A8D008CE459 /* ScrapPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 143185E9292B4A8D008CE459 /* ScrapPageViewController.swift */; };
@@ -286,6 +287,7 @@
 		141344D8292F803800187B86 /* UIControl+Combine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIControl+Combine.swift"; sourceTree = "<group>"; };
 		141344DA292F82BE00187B86 /* Feed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feed.swift; sourceTree = "<group>"; };
 		1418960129377593005A42D4 /* UIScrollView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIScrollView+.swift"; sourceTree = "<group>"; };
+		141A7A6F297E5BDC003DD926 /* ScrapViewModelError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrapViewModelError.swift; sourceTree = "<group>"; };
 		1422C62E292F08BC00337710 /* BCDateFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BCDateFormatter.swift; sourceTree = "<group>"; };
 		143185E7292B46F9008CE459 /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
 		143185E9292B4A8D008CE459 /* ScrapPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrapPageViewController.swift; sourceTree = "<group>"; };
@@ -585,6 +587,7 @@
 				140FBEE429750D0B006B7857 /* LoginViewModelError.swift */,
 				14D8C4D3297C0C0200DFE71F /* FeedDetailViewModelError.swift */,
 				14D8C4C5297BEDB900DFE71F /* HomeViewModelError.swift */,
+				141A7A6F297E5BDC003DD926 /* ScrapViewModelError.swift */,
 				140FBEF329756A3D006B7857 /* SignUpBlogViewModelError.swift */,
 			);
 			path = ViewModel;
@@ -1940,6 +1943,7 @@
 				148A054F2972F62600664CCB /* SignUpUseCase.swift in Sources */,
 				3B7491E92938DCCD00A4BEA0 /* SignUpDomainViewModel.swift in Sources */,
 				141344D5292F801100187B86 /* TypeConversion.swift in Sources */,
+				141A7A70297E5BDC003DD926 /* ScrapViewModelError.swift in Sources */,
 				D89AE4E82933AF1E00446AB3 /* ImageCacheManager.swift in Sources */,
 				1459C3BA292910B300FA885D /* RecommendFeedCell.swift in Sources */,
 				B50A27E529279F5D00DF3E1F /* LogInView.swift in Sources */,

--- a/burstcamp/burstcamp.xcodeproj/project.pbxproj
+++ b/burstcamp/burstcamp.xcodeproj/project.pbxproj
@@ -620,6 +620,13 @@
 			path = Singleton;
 			sourceTree = "<group>";
 		};
+		141A7A6E297E4D75003DD926 /* Cell */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Cell;
+			sourceTree = "<group>";
+		};
 		142C9340292F51A500F6428E /* UI */ = {
 			isa = PBXGroup;
 			children = (
@@ -1570,6 +1577,7 @@
 		B5BA278B2927B08800BDCE08 /* View */ = {
 			isa = PBXGroup;
 			children = (
+				141A7A6E297E4D75003DD926 /* Cell */,
 				B50A27AE29279F5D00DF3E1F /* NormalFeedCell */,
 				D8494D492927CBD4008157F1 /* DefaultButton.swift */,
 				D8494D4B2927CD6C008157F1 /* DefaultProfileImageView.swift */,

--- a/burstcamp/burstcamp/Data/Repositories/FeedRepository/DefaultFeedRepository.swift
+++ b/burstcamp/burstcamp/Data/Repositories/FeedRepository/DefaultFeedRepository.swift
@@ -15,6 +15,7 @@ final class DefaultFeedRepository: FeedRepository {
         self.bcFirestoreService = bcFirestoreService
     }
 
+    // MARK: - Home Feed 불러오기
     func fetchRecentHomeFeedList() async throws -> HomeFeedList {
         async let recommendFeed = bcFirestoreService.fetchRecommendFeed().map { Feed(feedAPIModel: $0) }
         async let normalFeed = bcFirestoreService.fetchLatestNormalFeeds().map { Feed(feedAPIModel: $0) }
@@ -28,6 +29,20 @@ final class DefaultFeedRepository: FeedRepository {
         return try await bcFirestoreService.fetchMoreNormalFeeds().map { Feed(feedAPIModel: $0)}
     }
 
+    // MARK: - Scrap 피드 불러오기
+    func fetchRecentScrapFeed(userUUID: String) async throws -> [Feed] {
+        return try await bcFirestoreService.fetchLatestScrapFeeds(userUUID: userUUID).map {
+            Feed(feedAPIModel: $0, isScraped: true)
+        }
+    }
+
+    func fetchMoreScrapFeed(userUUID: String) async throws -> [Feed] {
+        return try await bcFirestoreService.fetchMoreScrapFeeds(userUUID: userUUID).map {
+            Feed(feedAPIModel: $0, isScraped: true)
+        }
+    }
+
+    // MARK: 피드 스크랩
     func scrapFeed(_ feed: Feed, userUUID: String) async throws -> Feed {
         let scrapedFeed = feed.getScrapFeed()
         try await bcFirestoreService.scrapFeed(ScrapFeedAPIModel(feed: scrapedFeed), with: userUUID)

--- a/burstcamp/burstcamp/Data/Repositories/FeedRepository/DefaultFeedRepository.swift
+++ b/burstcamp/burstcamp/Data/Repositories/FeedRepository/DefaultFeedRepository.swift
@@ -51,7 +51,7 @@ final class DefaultFeedRepository: FeedRepository {
 
     func unScrapFeed(_ feed: Feed, userUUID: String) async throws -> Feed {
         let unScrapedFeed = feed.getUnScrapFeed()
-        try await bcFirestoreService.unScrapFeed(FeedAPIModel(feed: feed), with: userUUID)
+        try await bcFirestoreService.unScrapFeed(FeedAPIModel(feed: unScrapedFeed), with: userUUID)
         return unScrapedFeed
     }
 }

--- a/burstcamp/burstcamp/Domain/Interfaces/FeedRepository/FeedRepository.swift
+++ b/burstcamp/burstcamp/Domain/Interfaces/FeedRepository/FeedRepository.swift
@@ -10,6 +10,10 @@ import Foundation
 protocol FeedRepository {
     func fetchRecentHomeFeedList() async throws -> HomeFeedList
     func fetchMoreNormalFeed() async throws -> [Feed]
+
+    func fetchRecentScrapFeed(userUUID: String) async throws -> [Feed]
+    func fetchMoreScrapFeed(userUUID: String) async throws -> [Feed]
+
     func scrapFeed(_ feed: Feed, userUUID: String) async throws -> Feed
     func unScrapFeed(_ feed: Feed, userUUID: String) async throws -> Feed
 }

--- a/burstcamp/burstcamp/Domain/UseCase/Tab/Home/DefaultHomeUseCase.swift
+++ b/burstcamp/burstcamp/Domain/UseCase/Tab/Home/DefaultHomeUseCase.swift
@@ -29,6 +29,7 @@ final class DefaultHomeUseCase: HomeUseCase {
     }
 
     func fetchMoreNormalFeed() async throws -> [Feed] {
+        // TODO: scrap 여부
         return try await feedRepository.fetchMoreNormalFeed()
     }
 

--- a/burstcamp/burstcamp/Domain/UseCase/Tab/Home/DefaultHomeUseCase.swift
+++ b/burstcamp/burstcamp/Domain/UseCase/Tab/Home/DefaultHomeUseCase.swift
@@ -19,18 +19,16 @@ final class DefaultHomeUseCase: HomeUseCase {
         let userScrapFeedUUIDs = UserManager.shared.user.scrapFeedUUIDs
         let homeFeedList = try await feedRepository.fetchRecentHomeFeedList()
         let normalFeed = homeFeedList.normalFeed.map({ feed in
-            if userScrapFeedUUIDs.contains(feed.feedUUID) {
-                return feed.setIsScraped(true)
-            } else {
-                return feed
-            }
+            return userScrapFeedUUIDs.contains(feed.feedUUID) ? feed.setIsScraped(true) : feed
         })
         return HomeFeedList(recommendFeed: homeFeedList.recommendFeed, normalFeed: normalFeed)
     }
 
     func fetchMoreNormalFeed() async throws -> [Feed] {
-        // TODO: scrap 여부
-        return try await feedRepository.fetchMoreNormalFeed()
+        let userScrapFeedUUIDs = UserManager.shared.user.scrapFeedUUIDs
+        return try await feedRepository.fetchMoreNormalFeed().map { feed in
+            return userScrapFeedUUIDs.contains(feed.feedUUID) ? feed.setIsScraped(true) : feed
+        }
     }
 
     func scrapFeed(_ feed: Feed, userUUID: String) async throws -> Feed {

--- a/burstcamp/burstcamp/Domain/UseCase/Tab/Home/DefaultHomeUseCase.swift
+++ b/burstcamp/burstcamp/Domain/UseCase/Tab/Home/DefaultHomeUseCase.swift
@@ -21,6 +21,10 @@ final class DefaultHomeUseCase: HomeUseCase {
         let normalFeed = homeFeedList.normalFeed.map({ feed in
             return userScrapFeedUUIDs.contains(feed.feedUUID) ? feed.setIsScraped(true) : feed
         })
+        print("스크랩 배열", userScrapFeedUUIDs)
+        normalFeed.forEach { feed in
+            print("Use 케이스에서 출력", feed.title, feed.isScraped)
+        }
         return HomeFeedList(recommendFeed: homeFeedList.recommendFeed, normalFeed: normalFeed)
     }
 

--- a/burstcamp/burstcamp/Domain/UseCase/Tab/Home/DefaultHomeUseCase.swift
+++ b/burstcamp/burstcamp/Domain/UseCase/Tab/Home/DefaultHomeUseCase.swift
@@ -21,10 +21,6 @@ final class DefaultHomeUseCase: HomeUseCase {
         let normalFeed = homeFeedList.normalFeed.map({ feed in
             return userScrapFeedUUIDs.contains(feed.feedUUID) ? feed.setIsScraped(true) : feed
         })
-        print("스크랩 배열", userScrapFeedUUIDs)
-        normalFeed.forEach { feed in
-            print("Use 케이스에서 출력", feed.title, feed.isScraped)
-        }
         return HomeFeedList(recommendFeed: homeFeedList.recommendFeed, normalFeed: normalFeed)
     }
 

--- a/burstcamp/burstcamp/Domain/UseCase/Tab/ScrapPage/DefaultScrapPageUseCase.swift
+++ b/burstcamp/burstcamp/Domain/UseCase/Tab/ScrapPage/DefaultScrapPageUseCase.swift
@@ -8,4 +8,26 @@
 import Foundation
 
 final class DefaultScrapPageUseCase: ScrapPageUseCase {
+
+    private let feedRepository: FeedRepository
+
+    init(feedRepository: FeedRepository) {
+        self.feedRepository = feedRepository
+    }
+
+    func fetchRecentScrapFeed() async throws -> [Feed] {
+        let userUUID = UserManager.shared.user.userUUID
+        return try await feedRepository.fetchRecentScrapFeed(userUUID: userUUID)
+    }
+
+    func fetchMoreScrapFeed() async throws -> [Feed] {
+        let userUUID = UserManager.shared.user.userUUID
+        return try await feedRepository.fetchMoreScrapFeed(userUUID: userUUID)
+    }
+
+    func scrapFeed(_ feed: Feed, userUUID: String) async throws -> Feed {
+        return feed.isScraped
+        ? try await feedRepository.unScrapFeed(feed, userUUID: userUUID)
+        : try await feedRepository.scrapFeed(feed, userUUID: userUUID)
+    }
 }

--- a/burstcamp/burstcamp/Domain/UseCase/Tab/ScrapPage/ScrapPageUseCase.swift
+++ b/burstcamp/burstcamp/Domain/UseCase/Tab/ScrapPage/ScrapPageUseCase.swift
@@ -8,4 +8,7 @@
 import Foundation
 
 protocol ScrapPageUseCase {
+    func fetchRecentScrapFeed() async throws -> [Feed]
+    func fetchMoreScrapFeed() async throws -> [Feed]
+    func scrapFeed(_ feed: Feed, userUUID: String) async throws -> Feed
 }

--- a/burstcamp/burstcamp/Presentation/Common/View/NormalFeedCell/NormalFeedCell.swift
+++ b/burstcamp/burstcamp/Presentation/Common/View/NormalFeedCell/NormalFeedCell.swift
@@ -68,10 +68,6 @@ final class NormalFeedCell: UICollectionViewCell {
             $0.height.equalTo(Constant.Cell.normalFooterHeight)
         }
     }
-
-    func getButtonTapPublisher() -> AnyPublisher<Void, Never> {
-        return footerView.scrapButton.tapPublisher
-    }
 }
 
 extension NormalFeedCell {
@@ -79,5 +75,9 @@ extension NormalFeedCell {
         userInfoView.updateView(feedWriter: feed.writer)
         mainView.updateView(feed: feed)
         footerView.updateView(feed: feed)
+    }
+
+    func getButtonTapPublisher() -> AnyPublisher<Void, Never> {
+        return footerView.scrapButton.tapPublisher
     }
 }

--- a/burstcamp/burstcamp/Presentation/Coordinator/ScrapPage/ScrapPageCoordinator.swift
+++ b/burstcamp/burstcamp/Presentation/Coordinator/ScrapPage/ScrapPageCoordinator.swift
@@ -9,7 +9,7 @@ import Combine
 import UIKit
 
 protocol ScrapPageCoordinatorProtocol: TabBarChildCoordinator {
-    func moveToFeedDetail(feed: Feed)
+    func moveToFeedDetail(feed: Feed, scrapPageViewController: ScrapPageViewController)
 }
 
 final class ScrapPageCoordinator: ScrapPageCoordinatorProtocol, ContainFeedDetailCoordinator {
@@ -34,15 +34,15 @@ extension ScrapPageCoordinator {
             .sink { [weak self] event in
                 switch event {
                 case .moveToFeedDetail(let feed):
-                    self?.moveToFeedDetail(feed: feed)
+                    self?.moveToFeedDetail(feed: feed, scrapPageViewController: scrapPageViewController)
                 }
             }
             .store(in: &cancelBag)
     }
 
-    func moveToFeedDetail(feed: Feed) {
+    func moveToFeedDetail(feed: Feed, scrapPageViewController: ScrapPageViewController) {
         let feedDetailViewController = prepareFeedDetailViewController(feed: feed)
-        sinkFeedViewController(feedDetailViewController)
+        sink(feedDetailViewController, parentViewController: scrapPageViewController)
         self.navigationController.pushViewController(feedDetailViewController, animated: true)
     }
 }

--- a/burstcamp/burstcamp/Presentation/Factory/DependencyFactory.swift
+++ b/burstcamp/burstcamp/Presentation/Factory/DependencyFactory.swift
@@ -101,7 +101,8 @@ extension DependencyFactory {
     }
 
     func createScrapPageViewModel() -> ScrapPageViewModel {
-        let scrapPageUseCase = DefaultScrapPageUseCase()
+        let feedRepository = DefaultFeedRepository(bcFirestoreService: BCFirestoreService())
+        let scrapPageUseCase = DefaultScrapPageUseCase(feedRepository: feedRepository)
         return ScrapPageViewModel(scrapPageUseCase: scrapPageUseCase)
     }
 

--- a/burstcamp/burstcamp/Presentation/Tab/Detail/ViewModel/FeedDetailViewModel.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/Detail/ViewModel/FeedDetailViewModel.swift
@@ -89,7 +89,6 @@ final class FeedDetailViewModel {
         let userUUID = UserManager.shared.user.userUUID
         Task { [weak self] in
             let updatedFeed = try await feedDetailUseCase.scrapFeed(feed, userUUID: userUUID)
-            print(updatedFeed)
             self?.feedPublisher.value = updatedFeed
             self?.scrapPublisher.send(updatedFeed)
         }

--- a/burstcamp/burstcamp/Presentation/Tab/Home/View/RecommendFeedSection/RecommendFeedCell.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/Home/View/RecommendFeedSection/RecommendFeedCell.swift
@@ -58,7 +58,7 @@ final class RecommendFeedCell: UICollectionViewCell {
 }
 
 extension RecommendFeedCell {
-    func updateView(with feed: Feed) {
+    func updateFeedCell(with feed: Feed) {
         titleLabel.text = feed.title
         userView.updateView(feedWriter: feed.writer)
         backgroundColor = feed.writer.domain.brightColor

--- a/burstcamp/burstcamp/Presentation/Tab/Home/ViewController/HomeViewController.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/Home/ViewController/HomeViewController.swift
@@ -193,38 +193,32 @@ extension HomeViewController: UICollectionViewDelegate {
 // MARK: - DataSource
 extension HomeViewController {
     private func configureDataSource() {
+        let recommendFeedCellRegistration = UICollectionView.CellRegistration<RecommendFeedCell, Feed> { cell, _, feed in
+            cell.updateFeedCell(with: feed)
+        }
+
+        let normalFeedCellRegistration = UICollectionView.CellRegistration<NormalFeedCell, Feed> { cell, indexPath, feed in
+            self.bindNormalFeedCell(cell, index: indexPath.row, feedUUID: feed.feedUUID)
+            cell.updateFeedCell(with: feed)
+        }
+
         dataSource = UICollectionViewDiffableDataSource(
             collectionView: homeView.collectionView,
-            cellProvider: { collectionView, indexPath, _ in
+            cellProvider: { collectionView, indexPath, feed in
                 let feedCellType = FeedCellType(index: indexPath.section)
-
                 switch feedCellType {
                 case .recommend:
-                    guard let cell = collectionView.dequeueReusableCell(
-                        withReuseIdentifier: RecommendFeedCell.identifier,
-                        for: indexPath
-                    ) as? RecommendFeedCell
-                    else {
-                        return UICollectionViewCell()
-                    }
-                    let index = indexPath.row % 3
-                    let feed = self.viewModel.recommendFeedData[index]
-                    cell.updateView(with: feed)
-                    return cell
+                    return collectionView.dequeueConfiguredReusableCell(
+                        using: recommendFeedCellRegistration,
+                        for: indexPath,
+                        item: feed
+                    )
                 case .normal:
-                    guard let cell = collectionView.dequeueReusableCell(
-                        withReuseIdentifier: NormalFeedCell.identifier,
-                        for: indexPath
-                    ) as? NormalFeedCell
-                    else {
-                        return UICollectionViewCell()
-                    }
-                    let index = indexPath.row
-                    let feed = self.viewModel.normalFeedData[index]
-
-                    self.bindNormalFeedCell(cell, index: index, feedUUID: feed.feedUUID)
-                    cell.updateFeedCell(with: feed)
-                    return cell
+                    return collectionView.dequeueConfiguredReusableCell(
+                        using: normalFeedCellRegistration,
+                        for: indexPath,
+                        item: feed
+                    )
                 case .none:
                     return UICollectionViewCell()
                 }

--- a/burstcamp/burstcamp/Presentation/Tab/Home/ViewController/HomeViewController.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/Home/ViewController/HomeViewController.swift
@@ -309,8 +309,8 @@ extension HomeViewController: ContainFeedDetailViewController {
     func configure(scrapUpdatePublisher: AnyPublisher<Feed, Never>) {
         scrapUpdatePublisher
             .sink { [weak self] feed in
-                self?.reloadNormalFeedSection()
                 self?.viewModel.updateNormalFeed(feed)
+                self?.reloadNormalFeedSection()
             }
             .store(in: &cancelBag)
     }

--- a/burstcamp/burstcamp/Presentation/Tab/Home/ViewController/HomeViewController.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/Home/ViewController/HomeViewController.swift
@@ -265,9 +265,6 @@ extension HomeViewController {
         // TODO: Recommend Feed
 //        collectionViewSnapShot.appendItems(homeFeedList.recommendFeed, toSection: .recommend)
         collectionViewSnapShot.appendItems(homeFeedList.normalFeed, toSection: .normal)
-        homeFeedList.normalFeed.forEach { feed in
-            print(feed.title, feed.isScraped)
-        }
         dataSource.apply(collectionViewSnapShot, animatingDifferences: false)
     }
 

--- a/burstcamp/burstcamp/Presentation/Tab/Home/ViewController/HomeViewController.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/Home/ViewController/HomeViewController.swift
@@ -265,6 +265,9 @@ extension HomeViewController {
         // TODO: Recommend Feed
 //        collectionViewSnapShot.appendItems(homeFeedList.recommendFeed, toSection: .recommend)
         collectionViewSnapShot.appendItems(homeFeedList.normalFeed, toSection: .normal)
+        homeFeedList.normalFeed.forEach { feed in
+            print(feed.title, feed.isScraped)
+        }
         dataSource.apply(collectionViewSnapShot, animatingDifferences: false)
     }
 

--- a/burstcamp/burstcamp/Presentation/Tab/Home/ViewModel/HomeViewModel.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/Home/ViewModel/HomeViewModel.swift
@@ -150,7 +150,7 @@ final class HomeViewModel {
                     return
                 }
                 let updatedFeed = try await self.homeUseCase.scrapFeed(feed, userUUID: userUUID)
-                self.updateNormalFeed(updatedFeed)
+                _ = self.updateNormalFeed(updatedFeed)
                 self.scrapSuccess.send(updatedFeed)
             }
         } else {

--- a/burstcamp/burstcamp/Presentation/Tab/Home/ViewModel/HomeViewModel.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/Home/ViewModel/HomeViewModel.swift
@@ -129,7 +129,7 @@ final class HomeViewModel {
                     self?.moreFeed.send(normalFeed)
                 } catch {
                     if let error = error as? FirestoreServiceError, error == .lastFetch {
-                        showToast.send("모든 피드를 불러왔습니다.")
+                        showToast.send("모든 피드를 불러왔어요")
                         isLastFetch = true
                     } else {
                         showAlert.send(error)

--- a/burstcamp/burstcamp/Presentation/Tab/Home/ViewModel/HomeViewModel.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/Home/ViewModel/HomeViewModel.swift
@@ -161,7 +161,7 @@ final class HomeViewModel {
 
 // FeedDetail에서 변경된 Feed 업데이트
 extension HomeViewModel {
-    func updateNormalFeed(_ updatedFeed: Feed) {
+    func updateNormalFeed(_ updatedFeed: Feed) -> [Feed] {
         normalFeedData = normalFeedData.map { feed in
             if feed.feedUUID == updatedFeed.feedUUID {
                 return updatedFeed
@@ -169,5 +169,6 @@ extension HomeViewModel {
                 return feed
             }
         }
+        return normalFeedData
     }
 }

--- a/burstcamp/burstcamp/Presentation/Tab/ScrapPage/View/ScrapPageView.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/ScrapPage/View/ScrapPageView.swift
@@ -20,7 +20,6 @@ class ScrapPageView: UIView, ContainCollectionView {
         $0.collectionViewLayout = layout
         $0.showsVerticalScrollIndicator = false
         $0.backgroundColor = .clear
-        $0.register(NormalFeedCell.self, forCellWithReuseIdentifier: NormalFeedCell.identifier)
     }
 
     override init(frame: CGRect) {

--- a/burstcamp/burstcamp/Presentation/Tab/ScrapPage/ViewController/ScrapPageViewController.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/ScrapPage/ViewController/ScrapPageViewController.swift
@@ -26,7 +26,6 @@ final class ScrapPageViewController: UIViewController {
 
     let coordinatorPublisher = PassthroughSubject<ScrapPageCoordinatorEvent, Never>()
     private let viewWillAppearPublisher = PassthroughSubject<Void, Never>()
-    private let viewWillDisappearPublisher = PassthroughSubject<Void, Never>()
     private let paginationPublisher = PassthroughSubject<Void, Never>()
     private var cancelBag = Set<AnyCancellable>()
 
@@ -59,11 +58,6 @@ final class ScrapPageViewController: UIViewController {
         viewWillAppearPublisher.send(Void())
     }
 
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        viewWillDisappearPublisher.send(Void())
-    }
-
     private func collectionViewDelegate() {
         scrapPageView.collectionViewDelegate(viewController: self)
     }
@@ -81,7 +75,6 @@ final class ScrapPageViewController: UIViewController {
 
         let input = ScrapPageViewModel.Input(
             viewWillAppear: viewWillAppearPublisher.eraseToAnyPublisher(),
-            viewWillDisappear: viewWillDisappearPublisher.eraseToAnyPublisher(),
             viewDidRefresh: refreshControl.refreshPublisher,
             pagination: paginationPublisher.eraseToAnyPublisher()
         )

--- a/burstcamp/burstcamp/Presentation/Tab/ScrapPage/ViewController/ScrapPageViewController.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/ScrapPage/ViewController/ScrapPageViewController.swift
@@ -178,7 +178,7 @@ extension ScrapPageViewController: UICollectionViewDelegateFlowLayout {
 // MARK: - DataSource
 extension ScrapPageViewController {
     private func configureDataSource() {
-        let cellRegistration = UICollectionView.CellRegistration<NormalFeedCell, Feed> { cell, _ , feed in
+        let cellRegistration = UICollectionView.CellRegistration<NormalFeedCell, Feed> { cell, _, feed in
             self.bindNormalFeedCell(cell, feedUUID: feed.feedUUID)
             cell.updateFeedCell(with: feed)
         }
@@ -195,6 +195,8 @@ extension ScrapPageViewController {
     }
 
     private func refreshScrapFeedList(scrapFeedList: [Feed]) {
+        configureEmptyView()
+
         let previousScrapFeedData = collectionViewSnapshot.itemIdentifiers(inSection: .normal)
         collectionViewSnapshot.deleteItems(previousScrapFeedData)
 
@@ -207,9 +209,12 @@ extension ScrapPageViewController {
         dataSource.apply(collectionViewSnapshot, animatingDifferences: false)
     }
 
-    private func reloadScrapFeedSection() {
-        collectionViewSnapshot.reloadSections([.normal])
-        dataSource.apply(collectionViewSnapshot, animatingDifferences: false)
+    private func configureEmptyView() {
+        if viewModel.scrapFeedList.isEmpty {
+            scrapPageView.collectionView.configureEmptyView()
+        } else {
+            scrapPageView.collectionView.resetEmptyView()
+        }
     }
 }
 

--- a/burstcamp/burstcamp/Presentation/Tab/ScrapPage/ViewController/ScrapPageViewController.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/ScrapPage/ViewController/ScrapPageViewController.swift
@@ -195,13 +195,12 @@ extension ScrapPageViewController {
     }
 
     private func refreshScrapFeedList(scrapFeedList: [Feed]) {
-        configureEmptyView()
-
         let previousScrapFeedData = collectionViewSnapshot.itemIdentifiers(inSection: .normal)
         collectionViewSnapshot.deleteItems(previousScrapFeedData)
 
         collectionViewSnapshot.appendItems(scrapFeedList, toSection: .normal)
         dataSource.apply(collectionViewSnapshot, animatingDifferences: false)
+        configureEmptyView()
     }
 
     private func reloadScrapFeedList(additional scrapFeedList: [Feed]) {

--- a/burstcamp/burstcamp/Presentation/Tab/ScrapPage/ViewController/ScrapPageViewController.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/ScrapPage/ViewController/ScrapPageViewController.swift
@@ -117,12 +117,12 @@ final class ScrapPageViewController: UIViewController {
             .store(in: &cancelBag)
     }
 
-    private func bindNormalFeedCell(_ cell: NormalFeedCell, index: Int, feedUUID: String) {
+    private func bindNormalFeedCell(_ cell: NormalFeedCell, feedUUID: String) {
 
         let scrapButtonDidTap = cell.getButtonTapPublisher()
             .map { _  in
                 cell.footerView.scrapButton.isEnabled = false
-                return index
+                return feedUUID
             }
             .eraseToAnyPublisher()
 
@@ -178,8 +178,8 @@ extension ScrapPageViewController: UICollectionViewDelegateFlowLayout {
 // MARK: - DataSource
 extension ScrapPageViewController {
     private func configureDataSource() {
-        let cellRegistration = UICollectionView.CellRegistration<NormalFeedCell, Feed> { cell, indexPath, feed in
-            self.bindNormalFeedCell(cell, index: indexPath.row, feedUUID: feed.feedUUID)
+        let cellRegistration = UICollectionView.CellRegistration<NormalFeedCell, Feed> { cell, _ , feed in
+            self.bindNormalFeedCell(cell, feedUUID: feed.feedUUID)
             cell.updateFeedCell(with: feed)
         }
         dataSource = UICollectionViewDiffableDataSource(

--- a/burstcamp/burstcamp/Presentation/Tab/ScrapPage/ViewController/ScrapPageViewController.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/ScrapPage/ViewController/ScrapPageViewController.swift
@@ -178,7 +178,7 @@ extension ScrapPageViewController {
     private func configureDataSource() {
         dataSource = UICollectionViewDiffableDataSource(
             collectionView: scrapPageView.collectionView,
-            cellProvider: { collectionView, indexPath, itemIdentifier in
+            cellProvider: { collectionView, indexPath, _ in
                 guard let cell = collectionView.dequeueReusableCell(
                     withReuseIdentifier: NormalFeedCell.identifier,
                     for: indexPath

--- a/burstcamp/burstcamp/Presentation/Tab/ScrapPage/ViewController/ScrapPageViewController.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/ScrapPage/ViewController/ScrapPageViewController.swift
@@ -217,8 +217,11 @@ extension ScrapPageViewController: ContainFeedDetailViewController {
     func configure(scrapUpdatePublisher: AnyPublisher<Feed, Never>) {
         scrapUpdatePublisher
             .sink { [weak self] feed in
-                self?.viewModel.updateScrapFeed(feed)
-                self?.reloadScrapFeedSection()
+                guard let feedList = self?.viewModel.updateScrapFeed(feed) else {
+                    self?.showAlert(message: "피드 업데이트 중 에러가 발생했습니다.")
+                    return
+                }
+                self?.refreshScrapFeedList(scrapFeedList: feedList)
             }
             .store(in: &cancelBag)
     }

--- a/burstcamp/burstcamp/Presentation/Tab/ScrapPage/ViewModel/ScrapPageViewModel.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/ScrapPage/ViewModel/ScrapPageViewModel.swift
@@ -16,45 +16,27 @@ final class ScrapPageViewModel {
 
     var scrapFeedData: [Feed] = []
 
-    private let scrapSuccess = CurrentValueSubject<Feed?, Never>(nil)
-
-    private var cancelBag = Set<AnyCancellable>()
-    private var temporaryCancelBag = Set<AnyCancellable>()
-
     private let userUUID: String
     private let scrapPageUseCase: ScrapPageUseCase
-    private let localDataSource: FeedLocalDataSource
-    private let remoteDataSource: FeedRemoteDataSource
-    private let fetcher: Fetcher<[Feed], Error>
 
     init(
         scrapPageUseCase: ScrapPageUseCase,
-        userUUID: String = UserManager.shared.user.userUUID,
-        localDataSource: FeedLocalDataSource = FeedRealmDataSource.shared,
-        remoteDataSource: FeedRemoteDataSource = FeedRemoteDataSource.shared
+        userUUID: String = UserManager.shared.user.userUUID
     ) {
         self.scrapPageUseCase = scrapPageUseCase
-        self.localDataSource = localDataSource
-        self.remoteDataSource = remoteDataSource
         self.userUUID = userUUID
-
-        fetcher = Fetcher<[Feed], Error>(
-            onRemoteCombine: { remoteDataSource.scrapFeedListPublisher(userUUID: userUUID)
-                    .eraseToAnyPublisher() },
-            onLocalCombine: { localDataSource.scrapFeedListPublisher() },
-            onLocal: { localDataSource.cachedScrapFeedList() },
-            onUpdateLocal: { localDataSource.updateScrapFeedListOnCache($0) },
-            queue: RealmConfig.serialQueue
-        )
     }
 
     private let reloadData = CurrentValueSubject<Void?, Never>(nil)
     private let hideIndicator = CurrentValueSubject<Void?, Never>(nil)
     private let showAlert = CurrentValueSubject<Error?, Never>(nil)
 
+    private let scrapSuccess = CurrentValueSubject<Feed?, Never>(nil)
+
+    private var cancelBag = Set<AnyCancellable>()
+
     struct Input {
         let viewWillAppear: AnyPublisher<Void, Never>
-        let viewWillDisappear: AnyPublisher<Void, Never>
         let viewDidRefresh: AnyPublisher<Void, Never>
         let pagination: AnyPublisher<Void, Never>
     }
@@ -74,33 +56,33 @@ final class ScrapPageViewModel {
     }
 
     func transform(input: Input) -> Output {
-        input.viewWillDisappear
-            .sink { [weak self] _ in
-                guard let self = self else { return }
-                self.temporaryCancelBag = Set<AnyCancellable>()
-            }
-            .store(in: &cancelBag)
+//        input.viewWillDisappear
+//            .sink { [weak self] _ in
+//                guard let self = self else { return }
+//                self.temporaryCancelBag = Set<AnyCancellable>()
+//            }
+//            .store(in: &cancelBag)
 
         input.viewWillAppear
             .merge(with: input.viewDidRefresh)
             .sink { [weak self] _ in
                 guard let self = self else { return }
 
-                self.fetcher.fetch { status, data in
-                    self.scrapFeedData = data
-
-                    switch status {
-                    case .loading:
-                        self.reloadData.send(Void())
-                    case .success:
-                        self.hideIndicator.send(Void())
-                        self.reloadData.send(Void())
-                    case .failure(let error):
-                        self.hideIndicator.send(Void())
-                        self.showAlert.send(error)
-                    }
-                }
-                .store(in: &self.temporaryCancelBag)
+//                self.fetcher.fetch { status, data in
+//                    self.scrapFeedData = data
+//
+//                    switch status {
+//                    case .loading:
+//                        self.reloadData.send(Void())
+//                    case .success:
+//                        self.hideIndicator.send(Void())
+//                        self.reloadData.send(Void())
+//                    case .failure(let error):
+//                        self.hideIndicator.send(Void())
+//                        self.showAlert.send(error)
+//                    }
+//                }
+//                .store(in: &self.temporaryCancelBag)
             }
             .store(in: &cancelBag)
 

--- a/burstcamp/burstcamp/Presentation/Tab/ScrapPage/ViewModel/ScrapPageViewModel.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/ScrapPage/ViewModel/ScrapPageViewModel.swift
@@ -131,16 +131,25 @@ final class ScrapPageViewModel {
                     self?.scrapFeedList = scrapFeed
                     self?.recentScrapFeed.send(scrapFeed)
                 } catch {
-                    self?.recentScrapFeed.send([])
-                    if let error = error as? FirestoreServiceError, error == .lastFetch {
-                        showToast.send("스크랩 피드를 모두 불러왔어요")
-                        isLastFetch = true
+                    if let error = error as? FirestoreServiceError {
+                        self?.handleFirestoreServiceError(error)
                     } else {
                         showAlert.send(error)
                     }
                 }
                 isFetching = false
             }
+        }
+    }
+
+    private func handleFirestoreServiceError(_ error: FirestoreServiceError) {
+        if error == .scrapIsEmpty {
+            self.scrapFeedList = []
+            self.recentScrapFeed.send([])
+            isLastFetch = true
+        } else if error == .lastFetch {
+            showToast.send("스크랩 피드를 모두 불러왔어요")
+            isLastFetch = true
         }
     }
 

--- a/burstcamp/burstcamp/Presentation/Tab/ScrapPage/ViewModel/ScrapPageViewModel.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/ScrapPage/ViewModel/ScrapPageViewModel.swift
@@ -124,7 +124,7 @@ final class ScrapPageViewModel {
                 do {
                     let scrapFeed = try await self?.scrapPageUseCase.fetchRecentScrapFeed()
                     guard let scrapFeed = scrapFeed else {
-                        print("scrapFeedList 언래핑 에러")
+                        debugPrint("scrapFeedList 언래핑 에러")
                         isFetching = false
                         return
                     }

--- a/burstcamp/burstcamp/Presentation/Tab/ScrapPage/ViewModel/ScrapPageViewModel.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/ScrapPage/ViewModel/ScrapPageViewModel.swift
@@ -160,9 +160,10 @@ final class ScrapPageViewModel {
 }
 
 extension ScrapPageViewModel {
-    func updateScrapFeed(_ updatedScrapFeed: Feed) {
+    func updateScrapFeed(_ updatedScrapFeed: Feed) -> [Feed] {
         scrapFeedList = scrapFeedList.map { feed in
             return feed.feedUUID == updatedScrapFeed.feedUUID ? updatedScrapFeed : feed
         }
+        return scrapFeedList
     }
 }

--- a/burstcamp/burstcamp/Service/Firebase/Firestore/BCFirestoreService.swift
+++ b/burstcamp/burstcamp/Service/Firebase/Firestore/BCFirestoreService.swift
@@ -109,6 +109,10 @@ final class BCFirestoreService: BCFirestoreServiceProtocol {
 
         let result = try await firestoreService.getCollection(query: query)
         self.scrapPageLastSnapshot = result.lastSnapshot
+        if result.collectionData.isEmpty {
+            throw FirestoreServiceError.scrapIsEmpty
+        }
+
         if self.scrapPageLastSnapshot == nil {
             throw FirestoreServiceError.lastFetch
         }

--- a/burstcamp/burstcamp/Service/Firebase/Firestore/FirestoreServiceError.swift
+++ b/burstcamp/burstcamp/Service/Firebase/Firestore/FirestoreServiceError.swift
@@ -16,4 +16,5 @@ enum FirestoreServiceError: Error, Equatable {
     case batch
     case lastFetch
     case userListener
+    case scrapIsEmpty
 }

--- a/burstcamp/burstcamp/Service/Singleton/UserManager.swift
+++ b/burstcamp/burstcamp/Service/Singleton/UserManager.swift
@@ -41,9 +41,10 @@ final class UserManager {
         bCFirestoreUserListener.userPublisher(userUUID: user.userUUID)
             .sink { error in
                 fatalError("유저 정보를 불러오는데 실패 \(error)")
-            } receiveValue: { userAPIModel in
+            } receiveValue: { [weak self] userAPIModel in
                 let user = User(userAPIModel: userAPIModel)
-                self.userUpdatePublisher.send(user)
+                self?.user = user
+                self?.userUpdatePublisher.send(user)
             }
             .store(in: &cancelBag)
     }

--- a/burstcamp/burstcamp/Util/Error/ViewModel/ScrapViewModelError.swift
+++ b/burstcamp/burstcamp/Util/Error/ViewModel/ScrapViewModelError.swift
@@ -1,0 +1,20 @@
+//
+//  ScrapViewModelError.swift
+//  burstcamp
+//
+//  Created by youtak on 2023/01/23.
+//
+
+import Foundation
+
+enum ScrapPageViewModelError: LocalizedError {
+    case scrapFeed
+}
+
+extension ScrapPageViewModelError {
+    var errorDescription: String? {
+        switch self {
+        case .scrapFeed: return "피드를 스크랩 하는 중 오류가 발생했습니다."
+        }
+    }
+}


### PR DESCRIPTION
## 관련 이슈
<!--
이슈 번호 #000 작성  
ex) close #1 
--> 
- close #286 

## 내용
<!--
로직 설명  
필요시 스크린샷 첨부
--> 
- scrapPage Use Case 구현 
  - 최근 스크랩 피드 불러오기
  - 페이지네이션으로 추가 스크랩 피드 불러오기
  - 스크랩/언스크랩
- Diffable 적용
- 스크랩 카운트 - 1 안되던 오류 해결
- UserListner에서 UserManager - user 업데이트 안 하던 거 수정
- Empty View 적용

- Home, ScrapPage, FeedDetail 모두 연계 잘됨
  - Home - FeedDetail 스크랩 연계 됨
  -  ScrapPage - FeedDetail 스크랩 연계 됨
  - But, Home 탭에서 스크랩 한 거를 ScrapPage 탭 에서 확인하려면 refresh 해줘야하고, 
    Scrap Page 탭에서 스크랩/언스크랩한 거를 확인하려면 Home 탭에서 Refresh해줘야 함.
    각 탭은 다른 화면이라고 생각하면 될 듯. 
    지금은 홈에 피드가 적지만, 피드가 많아지면 스크랩 -> 홈으로가서 확인하는 일이 적음. 굳이 UnScrap 할 때마다 HomeView를 reload 해줄 필요 없음. 유저가 Refresh하는 플로우는 자연스럽다고 판단 됨

## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 
- Diffable을 처음 사용해보는데 잘 쓰고 있는 건지 헷갈림. 레퍼런스 보고 공부가 더 필요.
- 스크랩한 피드가 없을 때 에러처리를 통해 관리하고 있음. 더 깔끔하게 관리할 방법 있으면 좋겠음.

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
- 다음에 Recommend Cell 만 처리해주면 기본 기능은 사실상 전부 수정 완료.