### PR TITLE
[Refactor] Diffable DataSource 를 위한 DiffableFeed

### DIFF
--- a/burstcamp/burstcamp.xcodeproj/project.pbxproj
+++ b/burstcamp/burstcamp.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		143D93A6292E484100C67C27 /* burstcampTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 143D93A5292E484100C67C27 /* burstcampTests.swift */; };
 		143D93AD292E48C100C67C27 /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 143D93AC292E48C100C67C27 /* FirebaseAuth */; };
 		143D93B1292E4B9500C67C27 /* FirebaseFirestore in Frameworks */ = {isa = PBXBuildFile; productRef = 143D93B0292E4B9500C67C27 /* FirebaseFirestore */; };
+		145842B4297FF5C800C81878 /* DiffableFeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 145842B3297FF5C800C81878 /* DiffableFeed.swift */; };
 		1458C6952928FB1B00E00B80 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1458C6942928FB1B00E00B80 /* HomeView.swift */; };
 		1459C3BA292910B300FA885D /* RecommendFeedCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1459C3B9292910B300FA885D /* RecommendFeedCell.swift */; };
 		1459C3BC2929150200FA885D /* FeedCellType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1459C3BB2929150200FA885D /* FeedCellType.swift */; };
@@ -296,6 +297,7 @@
 		143185F7292B5C88008CE459 /* ContainCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainCollectionView.swift; sourceTree = "<group>"; };
 		143D93A3292E484100C67C27 /* burstcampTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = burstcampTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		143D93A5292E484100C67C27 /* burstcampTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = burstcampTests.swift; sourceTree = "<group>"; };
+		145842B3297FF5C800C81878 /* DiffableFeed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffableFeed.swift; sourceTree = "<group>"; };
 		1458C6942928FB1B00E00B80 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		1459C3B9292910B300FA885D /* RecommendFeedCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecommendFeedCell.swift; sourceTree = "<group>"; };
 		1459C3BB2929150200FA885D /* FeedCellType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedCellType.swift; sourceTree = "<group>"; };
@@ -1239,6 +1241,7 @@
 			children = (
 				B5FF711D2948DCA0008E69F2 /* RealmModel */,
 				141344DA292F82BE00187B86 /* Feed.swift */,
+				145842B3297FF5C800C81878 /* DiffableFeed.swift */,
 				14A93D412936F00F00790034 /* FeedWriter.swift */,
 				1459C3BB2929150200FA885D /* FeedCellType.swift */,
 			);
@@ -1877,6 +1880,7 @@
 				148A05622972F7B900664CCB /* MyPageUseCase.swift in Sources */,
 				B5DAD681292E58BF00C4A126 /* DefaultMultilLineLabel.swift in Sources */,
 				3B061FDD2928E8E300BFA71D /* SignUpCamperIDViewController.swift in Sources */,
+				145842B4297FF5C800C81878 /* DiffableFeed.swift in Sources */,
 				1496CF1E294070A3008F312F /* ContainFeedDetailCoordinator.swift in Sources */,
 				140438C0293F77DD004D035C /* Factory.swift in Sources */,
 				140FBEE529750D0B006B7857 /* LoginViewModelError.swift in Sources */,

--- a/burstcamp/burstcamp/Data/Local/FeedSingletonDataSource.swift
+++ b/burstcamp/burstcamp/Data/Local/FeedSingletonDataSource.swift
@@ -112,7 +112,7 @@ extension FeedSingletonDataSource {
     func toggleScrapFeed(modifiedFeed: Feed) {
         updateFeed(feedUUID: modifiedFeed.feedUUID) { feed in
             var newFeed = feed
-            newFeed.toggleScrap()
+//            newFeed.toggleScrap()
             updateScrapFeedList(changedFeed: newFeed)
             return newFeed
         }

--- a/burstcamp/burstcamp/Data/Network/FeedRemote/FeedRemoteDataSource.swift
+++ b/burstcamp/burstcamp/Data/Network/FeedRemote/FeedRemoteDataSource.swift
@@ -50,7 +50,7 @@ final class FeedRemoteDataSource {
         return Future {
             // feed의 스크랩 상태를 변경 해준다.
             var newFeed = feed
-            newFeed.toggleScrap()
+//            newFeed.toggleScrap()
 
             switch feed.isScraped {
             case true:

--- a/burstcamp/burstcamp/Domain/Model/Feed/DiffableFeed.swift
+++ b/burstcamp/burstcamp/Domain/Model/Feed/DiffableFeed.swift
@@ -1,0 +1,13 @@
+//
+//  DiffableFeed.swift
+//  burstcamp
+//
+//  Created by youtak on 2023/01/24.
+//
+
+import Foundation
+
+enum DiffableFeed: Hashable {
+    case normal(Feed)
+    case recommend(Feed)
+}

--- a/burstcamp/burstcamp/Domain/Model/Feed/Feed.swift
+++ b/burstcamp/burstcamp/Domain/Model/Feed/Feed.swift
@@ -70,24 +70,6 @@ extension Feed {
         )
     }
 
-    mutating func toggleScrap() {
-        isScraped ? unScrap() : scrap()
-    }
-
-    mutating func scrap() {
-        scrapCount += 1
-        isScraped = true
-        scrapDate = Date()
-    }
-
-    mutating func unScrap() {
-        if scrapCount > 0 {
-            scrapCount -= 1
-        }
-        isScraped = false
-        scrapDate = nil
-    }
-
     func setIsScraped(_ isScraped: Bool) -> Feed {
         return Feed(
             feedUUID: self.feedUUID,
@@ -99,6 +81,20 @@ extension Feed {
             content: self.content,
             scrapCount: self.scrapCount,
             isScraped: isScraped
+        )
+    }
+
+    func getMockUpFeed() -> Feed {
+        return Feed(
+            feedUUID: UUID().uuidString,
+            writer: self.writer,
+            title: self.title,
+            pubDate: self.pubDate,
+            url: self.url,
+            thumbnailURL: self.thumbnailURL,
+            content: self.content,
+            scrapCount: self.scrapCount,
+            isScraped: self.isScraped
         )
     }
 }

--- a/burstcamp/burstcamp/Domain/UseCase/Tab/Home/DefaultHomeUseCase.swift
+++ b/burstcamp/burstcamp/Domain/UseCase/Tab/Home/DefaultHomeUseCase.swift
@@ -21,7 +21,8 @@ final class DefaultHomeUseCase: HomeUseCase {
         let normalFeed = homeFeedList.normalFeed.map({ feed in
             return userScrapFeedUUIDs.contains(feed.feedUUID) ? feed.setIsScraped(true) : feed
         })
-        return HomeFeedList(recommendFeed: homeFeedList.recommendFeed, normalFeed: normalFeed)
+        let recommendFeed = recommendFeedForCarousel(homeFeedList.recommendFeed)
+        return HomeFeedList(recommendFeed: recommendFeed, normalFeed: normalFeed)
     }
 
     func fetchMoreNormalFeed() async throws -> [Feed] {
@@ -35,5 +36,18 @@ final class DefaultHomeUseCase: HomeUseCase {
         return feed.isScraped
         ? try await feedRepository.unScrapFeed(feed, userUUID: userUUID)
         : try await feedRepository.scrapFeed(feed, userUUID: userUUID)
+    }
+
+    // Carousel View를 위해 추천 피드를 2개 씩 복사해줘야 함
+    private func recommendFeedForCarousel(_ recommendFeedList: [Feed]) -> [Feed] {
+        let newArrayOne = makeMockUpRecommendFeed(recommendFeedList)
+        let newArrayTwo = makeMockUpRecommendFeed(recommendFeedList)
+        return newArrayOne + recommendFeedList + newArrayTwo
+    }
+
+    private func makeMockUpRecommendFeed(_ recommendFeedList: [Feed]) -> [Feed] {
+        return recommendFeedList.map {
+            return $0.getMockUpFeed()
+        }
     }
 }

--- a/burstcamp/burstcamp/Presentation/Tab/Home/ViewController/HomeViewController.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/Home/ViewController/HomeViewController.swift
@@ -206,7 +206,6 @@ extension HomeViewController {
             collectionView: homeView.collectionView,
             cellProvider: { collectionView, indexPath, diffableFeed in
 
-                let feedCellType = FeedCellType(index: indexPath.section)
                 switch diffableFeed {
                 case .recommend(let feed):
                     return collectionView.dequeueConfiguredReusableCell(

--- a/burstcamp/burstcamp/Presentation/Tab/Home/ViewController/HomeViewController.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/Home/ViewController/HomeViewController.swift
@@ -259,21 +259,13 @@ extension HomeViewController {
         collectionViewSnapShot.deleteItems(previousRecommendFeedData)
         collectionViewSnapShot.deleteItems(previousNormalFeedData)
 
-        // TODO: Recommend Feed
-//        collectionViewSnapShot.appendItems(homeFeedList.recommendFeed, toSection: .recommend)
-//        collectionViewSnapShot.appendItems(homeFeedList.normalFeed, toSection: .normal)
-        homeFeedList.recommendFeed.forEach {
-            collectionViewSnapShot.appendItems([DiffableFeed.recommend($0)], toSection: .recommend)
-        }
-        homeFeedList.normalFeed.forEach {
-            collectionViewSnapShot.appendItems([DiffableFeed.normal($0)], toSection: .normal)
-        }
+        snapShotAppend(feedList: homeFeedList.recommendFeed, toSection: .recommend)
+        snapShotAppend(feedList: homeFeedList.normalFeed, toSection: .normal)
         dataSource.apply(collectionViewSnapShot, animatingDifferences: false)
     }
 
     private func reloadHomeFeedList(additional normalFeedList: [Feed]) {
-        normalFeedList.forEach { collectionViewSnapShot.appendItems([DiffableFeed.normal($0)], toSection: .normal) }
-//        collectionViewSnapShot.appendItems(normalFeedList, toSection: .normal)
+        snapShotAppend(feedList: normalFeedList, toSection: .normal)
         dataSource.apply(collectionViewSnapShot, animatingDifferences: false)
     }
 
@@ -281,9 +273,16 @@ extension HomeViewController {
         let previousNormalFeedData = collectionViewSnapShot.itemIdentifiers(inSection: .normal)
         collectionViewSnapShot.deleteItems(previousNormalFeedData)
 
-        normalFeedList.forEach { collectionViewSnapShot.appendItems([DiffableFeed.normal($0)], toSection: .normal) }
-//        collectionViewSnapShot.appendItems(normalFeedList)
+        snapShotAppend(feedList: normalFeedList, toSection: .normal)
         dataSource.apply(collectionViewSnapShot, animatingDifferences: false)
+    }
+
+    private func snapShotAppend(feedList: [Feed], toSection: FeedCellType) {
+        if toSection == .normal {
+            feedList.forEach { collectionViewSnapShot.appendItems([DiffableFeed.normal($0)], toSection: .normal) }
+        } else if toSection == .recommend {
+            feedList.forEach { collectionViewSnapShot.appendItems([DiffableFeed.recommend($0)], toSection: .recommend) }
+        }
     }
 }
 


### PR DESCRIPTION
## 관련 이슈
<!--
이슈 번호 #000 작성  
ex) close #1 
--> 
- close #281 

## 내용
<!--
로직 설명  
필요시 스크린샷 첨부
--> 
- DiffableFeed 생성
  - Diffable DataSource의 경우  여러 개의 섹션에 동일한 Item이 들어갈 수 없음.
  - Feed를 래핑하는 DiffableFeed enum 타입을 만듦
  - ViewController에서 FeedList를 받아 래핑해서 Snapshot에 넣어줌
- Carousel(가로 무한 스크롤)을 위한 목업데이터 생성
  - Diffable Datasource의 경우 스냅샷에 똑같은 아이템이 안 들어감
  - 기존 Carousel View의 경우 아이템 좌, 우로 똑같은 를 만들어줬음. ex) 추천피드가 3개인 경우 3 + 3 + 3으로 피드를 구성했음
  - Diffbable의 경우 Hashable 해야함. Feed UUID를 새로 생성해서 목업 데이터를 만들어줌
  - 3(FeedUUID가 다른 목업 피드) + 3(추천 피드) + 3(FeedUUID가 다른 목업 피드)

## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 
- Diffable + Carousel View를 위한 더 좋은 방법이 있다면 알고 싶다.

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
https://hsnxcr.medium.com/uicollectionviewdiffabledatasource-wrapper-for-handling-multiple-section-layout-and-more-1c387b01d179