### PR TITLE
[Feat] UILabel에 baseLineOffset 적용

### DIFF
--- a/burstcamp/burstcamp/Util/Extension/UI/View/UILabel+LineHeight.swift
+++ b/burstcamp/burstcamp/Util/Extension/UI/View/UILabel+LineHeight.swift
@@ -17,10 +17,17 @@ extension UILabel {
         style.maximumLineHeight = lineHeight
         style.minimumLineHeight = lineHeight
 
+        let baseLineOffset = (lineHeight - font.lineHeight) / 2.0 / 2.0
+
         let attributes: [NSAttributedString.Key: Any] = [
-            .paragraphStyle: style
+            .paragraphStyle: style,
+            .baselineOffset: baseLineOffset
         ]
 
         self.attributedText = NSAttributedString(string: labelText, attributes: attributes)
     }
 }
+
+// baslineOffset 참고
+//https://sujinnaljin.medium.com/swift-label%EC%9D%98-line-height-%EC%84%A4%EC%A0%95-%EB%B0%8F-%EA%B0%80%EC%9A%B4%EB%8D%B0-%EC%A0%95%EB%A0%AC-962f7c6e7512
+//http://blog.eppz.eu/uilabel-line-height-letter-spacing-and-more-uilabel-typography-extensions/


### PR DESCRIPTION
## 관련 이슈
<!--
이슈 번호 #000 작성  
ex) close #1 
--> 
- close #293 

## 내용
<!--
로직 설명  
필요시 스크린샷 첨부
--> 
- UILabel에 BaseLine Offset 적용
  - Text 세로 가운데 정렬 함

|적용 전|적용 후 1|적용 후 2 |
|:---:|:---:|:---:|
|<img width = 200 src = "https://user-images.githubusercontent.com/71776532/214769266-300c2010-4ab0-41db-8f26-165da2468aa7.png">|<img width = 200 src = "https://user-images.githubusercontent.com/71776532/214769270-c6ac3208-0530-4649-9f74-92b0d1b4c5ff.png">|<img width = 200 src = "https://user-images.githubusercontent.com/71776532/214769276-0c19962f-5dde-4261-be88-8a04556f7860.png">|

"적용 후 2" 에서 덧칠 된 부분이 1 줄임. 세로 가운데 정렬된 거를 확인할 수 있음

## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
- https://sujinnaljin.medium.com/swift-label%EC%9D%98-line-height-%EC%84%A4%EC%A0%95-%EB%B0%8F-%EA%B0%80%EC%9A%B4%EB%8D%B0-%EC%A0%95%EB%A0%AC-962f7c6e7512
- http://blog.eppz.eu/uilabel-line-height-letter-spacing-and-more-uilabel-typography-extensions/
