### PR TITLE
[Fix] 295 에러 다른 기기에서 로그인시 재 가입해야하던 오류

### DIFF
--- a/burstcamp/burstcamp.xcodeproj/project.pbxproj
+++ b/burstcamp/burstcamp.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		140438BB293F6FD7004D035C /* HomeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 140438BA293F6FD7004D035C /* HomeCoordinator.swift */; };
 		140438BD293F6FDF004D035C /* ScrapPageCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 140438BC293F6FDF004D035C /* ScrapPageCoordinator.swift */; };
 		140438C0293F77DD004D035C /* Factory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 140438BF293F77DD004D035C /* Factory.swift */; };
+		1404DA43298259A100228E50 /* UserRepositoryError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1404DA42298259A100228E50 /* UserRepositoryError.swift */; };
+		1404DA4529825A2E00228E50 /* LoginUseCaseError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1404DA4429825A2E00228E50 /* LoginUseCaseError.swift */; };
 		140E210429443E6300D6E2E5 /* FirestoreService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 140E210329443E6300D6E2E5 /* FirestoreService.swift */; };
 		140E21062944519E00D6E2E5 /* BCFirestoreService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 140E21052944519E00D6E2E5 /* BCFirestoreService.swift */; };
 		140E21092944688B00D6E2E5 /* Future+Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 140E21082944688B00D6E2E5 /* Future+Async.swift */; };
@@ -265,6 +267,8 @@
 		140438BA293F6FD7004D035C /* HomeCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCoordinator.swift; sourceTree = "<group>"; };
 		140438BC293F6FDF004D035C /* ScrapPageCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrapPageCoordinator.swift; sourceTree = "<group>"; };
 		140438BF293F77DD004D035C /* Factory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Factory.swift; sourceTree = "<group>"; };
+		1404DA42298259A100228E50 /* UserRepositoryError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserRepositoryError.swift; sourceTree = "<group>"; };
+		1404DA4429825A2E00228E50 /* LoginUseCaseError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginUseCaseError.swift; sourceTree = "<group>"; };
 		140E210329443E6300D6E2E5 /* FirestoreService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirestoreService.swift; sourceTree = "<group>"; };
 		140E21052944519E00D6E2E5 /* BCFirestoreService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BCFirestoreService.swift; sourceTree = "<group>"; };
 		140E21082944688B00D6E2E5 /* Future+Async.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Future+Async.swift"; sourceTree = "<group>"; };
@@ -613,6 +617,14 @@
 			path = LoadingVIew;
 			sourceTree = "<group>";
 		};
+		1404DA412982599800228E50 /* Repository */ = {
+			isa = PBXGroup;
+			children = (
+				1404DA42298259A100228E50 /* UserRepositoryError.swift */,
+			);
+			path = Repository;
+			sourceTree = "<group>";
+		};
 		140E210029443D2200D6E2E5 /* Firestore */ = {
 			isa = PBXGroup;
 			children = (
@@ -767,6 +779,7 @@
 		143216542935C3320034DE9F /* Error */ = {
 			isa = PBXGroup;
 			children = (
+				1404DA412982599800228E50 /* Repository */,
 				140FBEE62975111A006B7857 /* DataSource */,
 				140FBEE329750D04006B7857 /* ViewModel */,
 				14A34D51297444D700501A66 /* UseCase */,
@@ -1284,6 +1297,7 @@
 			children = (
 				14A34D54297444F000501A66 /* SignUpUseCaseError.swift */,
 				140FBEF1297521A3006B7857 /* MyPageUseCaseError.swift */,
+				1404DA4429825A2E00228E50 /* LoginUseCaseError.swift */,
 			);
 			path = UseCase;
 			sourceTree = "<group>";
@@ -1940,6 +1954,7 @@
 				B50A27EB29279F5D00DF3E1F /* DefaultUserInfoView.swift in Sources */,
 				D84452EE292CA569008E811B /* MyPageEditViewModel.swift in Sources */,
 				14755A4C2973FA8C0036B71D /* LoginRepository.swift in Sources */,
+				1404DA43298259A100228E50 /* UserRepositoryError.swift in Sources */,
 				D89AE4E62933AEF900446AB3 /* UIImageView+Cache.swift in Sources */,
 				B50A27CF29279F5D00DF3E1F /* Constant.swift in Sources */,
 				D8576F3629378F51002885FE /* URLRegularExpression.swift in Sources */,
@@ -1999,6 +2014,7 @@
 				141A7A70297E5BDC003DD926 /* ScrapViewModelError.swift in Sources */,
 				D89AE4E82933AF1E00446AB3 /* ImageCacheManager.swift in Sources */,
 				1459C3BA292910B300FA885D /* RecommendFeedCell.swift in Sources */,
+				1404DA4529825A2E00228E50 /* LoginUseCaseError.swift in Sources */,
 				B50A27E529279F5D00DF3E1F /* LogInView.swift in Sources */,
 				148EF12C29791B0F00190471 /* DefaultImageRepository.swift in Sources */,
 				D8494D4E2927CE64008157F1 /* Domain.swift in Sources */,

--- a/burstcamp/burstcamp/Data/Repositories/UserRepository/DefaultUserRepository.swift
+++ b/burstcamp/burstcamp/Data/Repositories/UserRepository/DefaultUserRepository.swift
@@ -19,7 +19,15 @@ final class DefaultUserRepository: UserRepository {
     // MARK: User
 
     func fetchUser(_ userUUID: String) async throws -> User {
-        return try await User(userAPIModel: bcFirestoreService.fetchUser(userUUID: userUUID))
+        do {
+            return try await User(userAPIModel: bcFirestoreService.fetchUser(userUUID: userUUID))
+        } catch {
+            if let error = error as? FirestoreServiceError, error == .getDocument {
+                throw UserRepositoryError.userNotExist
+            } else {
+                throw error
+            }
+        }
     }
 
     func saveUser(_ user: User) async throws {

--- a/burstcamp/burstcamp/Data/Repositories/UserRepository/DefaultUserRepository.swift
+++ b/burstcamp/burstcamp/Data/Repositories/UserRepository/DefaultUserRepository.swift
@@ -18,6 +18,10 @@ final class DefaultUserRepository: UserRepository {
     }
     // MARK: User
 
+    func fetchUser(_ userUUID: String) async throws -> User {
+        return try await User(userAPIModel: bcFirestoreService.fetchUser(userUUID: userUUID))
+    }
+
     func saveUser(_ user: User) async throws {
         let userAPIModel = userToAPIModel(user)
         try await bcFirestoreService.saveUser(userUUID: user.userUUID, user: userAPIModel)

--- a/burstcamp/burstcamp/Domain/Interfaces/UserRepository/UserRepository.swift
+++ b/burstcamp/burstcamp/Domain/Interfaces/UserRepository/UserRepository.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 protocol UserRepository {
+    func fetchUser(_ userUUID: String) async throws -> User
     func saveUser(_ user: User) async throws
     func updateUser(_ user: User) async throws
     func updateUserPushState(userUUID: String, isPushOn: Bool) async throws

--- a/burstcamp/burstcamp/Domain/UseCase/Auth/Login/LoginUseCase.swift
+++ b/burstcamp/burstcamp/Domain/UseCase/Auth/Login/LoginUseCase.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 protocol LoginUseCase {
+    func checkIsExist(userUUID: String) async throws -> Bool
     func isLoggedIn() -> Bool
     func login(code: String) async throws ->  (userNickname: String, userUUID: String)
 }

--- a/burstcamp/burstcamp/Domain/UseCase/Tab/MyPage/DefaultMyPageUseCase.swift
+++ b/burstcamp/burstcamp/Domain/UseCase/Tab/MyPage/DefaultMyPageUseCase.swift
@@ -18,7 +18,7 @@ final class DefaultMyPageUseCase: MyPageUseCase {
         self.userRepository = userRepository
         self.imageRepository = imageRepository
     }
-
+    
     func withdrawal(code: String, userUUID: String) async throws {
         let isSuccess = try await loginRepository.withdrawal(code: code)
         try await imageRepository.deleteProfileImage(userUUID: userUUID)

--- a/burstcamp/burstcamp/Domain/UseCase/Tab/MyPage/DefaultMyPageUseCase.swift
+++ b/burstcamp/burstcamp/Domain/UseCase/Tab/MyPage/DefaultMyPageUseCase.swift
@@ -18,7 +18,7 @@ final class DefaultMyPageUseCase: MyPageUseCase {
         self.userRepository = userRepository
         self.imageRepository = imageRepository
     }
-    
+
     func withdrawal(code: String, userUUID: String) async throws {
         let isSuccess = try await loginRepository.withdrawal(code: code)
         try await imageRepository.deleteProfileImage(userUUID: userUUID)

--- a/burstcamp/burstcamp/Presentation/Auth/LogIn/ViewModel/LogInViewModel.swift
+++ b/burstcamp/burstcamp/Presentation/Auth/LogIn/ViewModel/LogInViewModel.swift
@@ -44,6 +44,12 @@ final class LogInViewModel {
     func login(code: String) async throws {
         let (userNickname, userUUID) = try await loginUseCase.login(code: code)
         UserManager.shared.setUserUUID(userUUID)
-        logInPublisher.send(.moveToDomainScreen(userNickname: userNickname))
+
+        let isUserExist = try await loginUseCase.checkIsExist(userUUID: userUUID)
+        if isUserExist {
+            logInPublisher.send(.moveToTabBarScreen)
+        } else {
+            logInPublisher.send(.moveToDomainScreen(userNickname: userNickname))
+        }
     }
 }

--- a/burstcamp/burstcamp/Presentation/Factory/DependencyFactory.swift
+++ b/burstcamp/burstcamp/Presentation/Factory/DependencyFactory.swift
@@ -53,7 +53,8 @@ final class DependencyFactory: DependencyFactoryProtocol {
 extension DependencyFactory {
     func createLoginUseCase() -> LoginUseCase {
         let loginRepository = createLoginRepository()
-        return DefaultLoginUseCase(loginRepository: loginRepository)
+        let userRepository = createUserRepository()
+        return DefaultLoginUseCase(loginRepository: loginRepository, userRepository: userRepository)
     }
 
     // MARK: - ViewModel

--- a/burstcamp/burstcamp/Service/Singleton/UserManager.swift
+++ b/burstcamp/burstcamp/Service/Singleton/UserManager.swift
@@ -37,7 +37,7 @@ final class UserManager {
     }
 
     func addUserListener() {
-        if user.userUUID.isEmpty { fatalError("Listenr를 위한 UserUUID가 없음")}
+        if user.userUUID.isEmpty { fatalError("Listenr를 위한 UserUUID가 없음") }
         bCFirestoreUserListener.userPublisher(userUUID: user.userUUID)
             .sink { error in
                 fatalError("유저 정보를 불러오는데 실패 \(error)")

--- a/burstcamp/burstcamp/Util/Error/Repository/UserRepositoryError.swift
+++ b/burstcamp/burstcamp/Util/Error/Repository/UserRepositoryError.swift
@@ -1,0 +1,8 @@
+//
+//  UserRepositoryError.swift
+//  burstcamp
+//
+//  Created by youtak on 2023/01/26.
+//
+
+import Foundation

--- a/burstcamp/burstcamp/Util/Error/Repository/UserRepositoryError.swift
+++ b/burstcamp/burstcamp/Util/Error/Repository/UserRepositoryError.swift
@@ -6,3 +6,7 @@
 //
 
 import Foundation
+
+enum UserRepositoryError: Error {
+    case userNotExist
+}

--- a/burstcamp/burstcamp/Util/Error/UseCase/LoginUseCaseError.swift
+++ b/burstcamp/burstcamp/Util/Error/UseCase/LoginUseCaseError.swift
@@ -1,0 +1,8 @@
+//
+//  LoginUseCaseError.swift
+//  burstcamp
+//
+//  Created by youtak on 2023/01/26.
+//
+
+import Foundation

--- a/burstcamp/burstcamp/Util/Error/UseCase/LoginUseCaseError.swift
+++ b/burstcamp/burstcamp/Util/Error/UseCase/LoginUseCaseError.swift
@@ -6,3 +6,7 @@
 //
 
 import Foundation
+
+enum LoginUseCaseError: Error {
+    case fetchUser
+}


### PR DESCRIPTION
## 관련 이슈
<!--
이슈 번호 #000 작성  
ex) close #1 
--> 
- close #295 

## 내용
<!--
로직 설명  
필요시 스크린샷 첨부
--> 
- 로그인 시 firestore에 User 정보 있는지 확인
  - 있으면 TabBar로
  - 없으면 Auth로
- 기존 기기에서 이전 버전이 깔려있으면 로그인은 되어있는데 KeyChain에 값이 없는 경우가 있어서 에러가 발생했음. 이를 막기 위해 KeyChain 값이 nil이면 로그아웃으로 판별함
  - 재로그인시 KeyChain에 값이 저장
- 현재 로그인하고 HomeViewController로 넘어가면 에러가 발생함. didFailToRegisterForRemoteNotificationsWithError
  - UNUserNotificationCenterDelegate를 주석 처리해놔서 그런거 같음. 이거 때문에 로그인해서 Home화면 들어가면 화면이 안 움직임. 추후 주석 풀고 제대로 동작하는지 확인해봐야겠음. 

## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
