### PR TITLE
[Refactor] HomeViewController에서 FirestoreService 제거

### DIFF
--- a/burstcamp/burstcamp/Domain/UseCase/Tab/Home/DefaultHomeUseCase.swift
+++ b/burstcamp/burstcamp/Domain/UseCase/Tab/Home/DefaultHomeUseCase.swift
@@ -10,9 +10,11 @@ import Foundation
 final class DefaultHomeUseCase: HomeUseCase {
 
     private let feedRepository: FeedRepository
+    private let userRepository: UserRepository
 
-    init(feedRepository: FeedRepository) {
+    init(feedRepository: FeedRepository, userRepository: UserRepository) {
         self.feedRepository = feedRepository
+        self.userRepository = userRepository
     }
 
     func fetchRecentHomeFeedList() async throws -> HomeFeedList {
@@ -36,6 +38,13 @@ final class DefaultHomeUseCase: HomeUseCase {
         return feed.isScraped
         ? try await feedRepository.unScrapFeed(feed, userUUID: userUUID)
         : try await feedRepository.scrapFeed(feed, userUUID: userUUID)
+    }
+
+    func updateUserPushState(to pushState: Bool) async throws {
+        let userUUID = UserManager.shared.user.userUUID
+        if !userUUID.isEmpty {
+            try await userRepository.updateUserPushState(userUUID: userUUID, isPushOn: pushState)
+        }
     }
 
     // Carousel View를 위해 추천 피드를 2개 씩 복사해줘야 함

--- a/burstcamp/burstcamp/Domain/UseCase/Tab/Home/HomeUseCase.swift
+++ b/burstcamp/burstcamp/Domain/UseCase/Tab/Home/HomeUseCase.swift
@@ -11,4 +11,5 @@ protocol HomeUseCase {
     func fetchRecentHomeFeedList() async throws -> HomeFeedList
     func fetchMoreNormalFeed() async throws -> [Feed]
     func scrapFeed(_ feed: Feed, userUUID: String) async throws -> Feed
+    func updateUserPushState(to pushState: Bool) async throws
 }

--- a/burstcamp/burstcamp/Presentation/Factory/DependencyFactory.swift
+++ b/burstcamp/burstcamp/Presentation/Factory/DependencyFactory.swift
@@ -97,7 +97,8 @@ extension DependencyFactory {
 
     func createHomeViewModel() -> HomeViewModel {
         let feedRepository = DefaultFeedRepository(bcFirestoreService: BCFirestoreService())
-        let homeUseCase = DefaultHomeUseCase(feedRepository: feedRepository)
+        let userRepository = createUserRepository()
+        let homeUseCase = DefaultHomeUseCase(feedRepository: feedRepository, userRepository: userRepository)
         return HomeViewModel(homeUseCase: homeUseCase)
     }
 

--- a/burstcamp/burstcamp/Presentation/Tab/Home/ViewController/HomeViewController.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/Home/ViewController/HomeViewController.swift
@@ -314,11 +314,7 @@ extension HomeViewController: UNUserNotificationCenterDelegate {
         UNUserNotificationCenter.current().requestAuthorization(
             options: authOptions
         ) { isPushOn, _ in
-            let userUUID = UserManager.shared.user.userUUID
-            if !userUUID.isEmpty {
-                // TODO: push 상태 업데이트
-//                FirestoreUser.update(userUUID: userUUID, isPushOn: isPushOn)
-            }
+            self.viewModel.updateUserScrapState(to: isPushOn)
         }
         application.registerForRemoteNotifications()
     }

--- a/burstcamp/burstcamp/Presentation/Tab/Home/ViewModel/HomeViewModel.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/Home/ViewModel/HomeViewModel.swift
@@ -159,6 +159,18 @@ final class HomeViewModel {
     }
 }
 
+extension HomeViewModel {
+    func updateUserScrapState(to scrapState: Bool) {
+        Task { [weak self] in
+            do {
+                try await self?.homeUseCase.updateUserPushState(to: scrapState)
+            } catch {
+                showAlert.send(HomeViewModelError.pushState)
+            }
+        }
+    }
+}
+
 // FeedDetail에서 변경된 Feed 업데이트
 extension HomeViewModel {
     func updateNormalFeed(_ updatedFeed: Feed) -> [Feed] {

--- a/burstcamp/burstcamp/Service/Singleton/UserManager.swift
+++ b/burstcamp/burstcamp/Service/Singleton/UserManager.swift
@@ -24,7 +24,6 @@ final class UserManager {
     private func userByKeyChain() {
         if let user = KeyChainManager.readUser() {
             self.user = user
-            print("키체인 매니저", user)
         }
     }
 

--- a/burstcamp/burstcamp/Util/Error/ViewModel/HomeViewModelError.swift
+++ b/burstcamp/burstcamp/Util/Error/ViewModel/HomeViewModelError.swift
@@ -10,6 +10,7 @@ import Foundation
 enum HomeViewModelError: LocalizedError {
     case feedIndex
     case feedUpdate
+    case pushState
 }
 
 extension HomeViewModelError {
@@ -17,6 +18,7 @@ extension HomeViewModelError {
         switch self {
         case .feedIndex: return "피드에 접근하는데 오류가 발생했습니다.(index)"
         case .feedUpdate: return "피드 업데이트하는데 오류가 발생했습니다."
+        case .pushState: return "푸시 상태를 업데이트하는데 오류가 발생했습니다."
         }
     }
 }


### PR DESCRIPTION
UseCase로 이동

## 관련 이슈
<!--
이슈 번호 #000 작성  
ex) close #1 
--> 
- close #297 

## 내용
<!--
로직 설명  
필요시 스크린샷 첨부
--> 
- HomviewController에서 push 상태 저장 로직 -> UseCase로 이동

## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
