### PR TITLE
[Feature] 애플 로그인으로 게스트 모드 로그인

### DIFF
--- a/burstcamp/burstcamp.xcodeproj/project.pbxproj
+++ b/burstcamp/burstcamp.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		1404DA43298259A100228E50 /* UserRepositoryError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1404DA42298259A100228E50 /* UserRepositoryError.swift */; };
 		1404DA4529825A2E00228E50 /* LoginUseCaseError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1404DA4429825A2E00228E50 /* LoginUseCaseError.swift */; };
 		140B8751298775A300436F65 /* String+sha256.swift in Sources */ = {isa = PBXBuildFile; fileRef = 140B8750298775A300436F65 /* String+sha256.swift */; };
+		140B87532987870F00436F65 /* AuthButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 140B87522987870F00436F65 /* AuthButton.swift */; };
 		140E210429443E6300D6E2E5 /* FirestoreService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 140E210329443E6300D6E2E5 /* FirestoreService.swift */; };
 		140E21062944519E00D6E2E5 /* BCFirestoreService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 140E21052944519E00D6E2E5 /* BCFirestoreService.swift */; };
 		140E21092944688B00D6E2E5 /* Future+Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 140E21082944688B00D6E2E5 /* Future+Async.swift */; };
@@ -275,6 +276,7 @@
 		1404DA42298259A100228E50 /* UserRepositoryError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserRepositoryError.swift; sourceTree = "<group>"; };
 		1404DA4429825A2E00228E50 /* LoginUseCaseError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginUseCaseError.swift; sourceTree = "<group>"; };
 		140B8750298775A300436F65 /* String+sha256.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+sha256.swift"; sourceTree = "<group>"; };
+		140B87522987870F00436F65 /* AuthButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthButton.swift; sourceTree = "<group>"; };
 		140E210329443E6300D6E2E5 /* FirestoreService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirestoreService.swift; sourceTree = "<group>"; };
 		140E21052944519E00D6E2E5 /* BCFirestoreService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BCFirestoreService.swift; sourceTree = "<group>"; };
 		140E21082944688B00D6E2E5 /* Future+Async.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Future+Async.swift"; sourceTree = "<group>"; };
@@ -573,6 +575,7 @@
 			children = (
 				B597F9542935B94B0022D3E6 /* DefaultToggleButton.swift */,
 				D8494D492927CBD4008157F1 /* DefaultButton.swift */,
+				140B87522987870F00436F65 /* AuthButton.swift */,
 			);
 			path = Button;
 			sourceTree = "<group>";
@@ -2166,6 +2169,7 @@
 				141344CF292F800300187B86 /* UIStackView+addArrangedSubviews.swift in Sources */,
 				140FBEEB297511DB006B7857 /* URLSessionServiceError.swift in Sources */,
 				14D8C4C6297BEDB900DFE71F /* HomeViewModelError.swift in Sources */,
+				140B87532987870F00436F65 /* AuthButton.swift in Sources */,
 				1418960229377593005A42D4 /* UIScrollView+.swift in Sources */,
 				3B74920D293DCCAC00A4BEA0 /* GithubError.swift in Sources */,
 				143185EE292B4ABC008CE459 /* ScrapPageView.swift in Sources */,

--- a/burstcamp/burstcamp.xcodeproj/project.pbxproj
+++ b/burstcamp/burstcamp.xcodeproj/project.pbxproj
@@ -16,6 +16,8 @@
 		1404DA4529825A2E00228E50 /* LoginUseCaseError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1404DA4429825A2E00228E50 /* LoginUseCaseError.swift */; };
 		140B8751298775A300436F65 /* String+sha256.swift in Sources */ = {isa = PBXBuildFile; fileRef = 140B8750298775A300436F65 /* String+sha256.swift */; };
 		140B87532987870F00436F65 /* AuthButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 140B87522987870F00436F65 /* AuthButton.swift */; };
+		140B87562987993300436F65 /* LoginProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 140B87552987993300436F65 /* LoginProvider.swift */; };
+		140B87592987B6EF00436F65 /* AppleAuthViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 140B87582987B6EF00436F65 /* AppleAuthViewController.swift */; };
 		140E210429443E6300D6E2E5 /* FirestoreService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 140E210329443E6300D6E2E5 /* FirestoreService.swift */; };
 		140E21062944519E00D6E2E5 /* BCFirestoreService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 140E21052944519E00D6E2E5 /* BCFirestoreService.swift */; };
 		140E21092944688B00D6E2E5 /* Future+Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 140E21082944688B00D6E2E5 /* Future+Async.swift */; };
@@ -277,6 +279,8 @@
 		1404DA4429825A2E00228E50 /* LoginUseCaseError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginUseCaseError.swift; sourceTree = "<group>"; };
 		140B8750298775A300436F65 /* String+sha256.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+sha256.swift"; sourceTree = "<group>"; };
 		140B87522987870F00436F65 /* AuthButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthButton.swift; sourceTree = "<group>"; };
+		140B87552987993300436F65 /* LoginProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginProvider.swift; sourceTree = "<group>"; };
+		140B87582987B6EF00436F65 /* AppleAuthViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleAuthViewController.swift; sourceTree = "<group>"; };
 		140E210329443E6300D6E2E5 /* FirestoreService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirestoreService.swift; sourceTree = "<group>"; };
 		140E21052944519E00D6E2E5 /* BCFirestoreService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BCFirestoreService.swift; sourceTree = "<group>"; };
 		140E21082944688B00D6E2E5 /* Future+Async.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Future+Async.swift"; sourceTree = "<group>"; };
@@ -637,6 +641,22 @@
 				14FF7A2B2983854F001D6EDF /* UserRepository */,
 			);
 			path = Repository;
+			sourceTree = "<group>";
+		};
+		140B87542987992600436F65 /* Login */ = {
+			isa = PBXGroup;
+			children = (
+				140B87552987993300436F65 /* LoginProvider.swift */,
+			);
+			path = Login;
+			sourceTree = "<group>";
+		};
+		140B87572987B6E500436F65 /* Base */ = {
+			isa = PBXGroup;
+			children = (
+				140B87582987B6EF00436F65 /* AppleAuthViewController.swift */,
+			);
+			path = Base;
 			sourceTree = "<group>";
 		};
 		140E210029443D2200D6E2E5 /* Firestore */ = {
@@ -1254,6 +1274,7 @@
 		149304A92963F1EE00B9BC71 /* User */ = {
 			isa = PBXGroup;
 			children = (
+				140B87542987992600436F65 /* Login */,
 				D89AE5002936221600446AB3 /* ScrapUser.swift */,
 				D8494D532927D0DC008157F1 /* User.swift */,
 				D8494D4D2927CE64008157F1 /* Domain.swift */,
@@ -1696,6 +1717,7 @@
 		B5BA278A2927B08100BDCE08 /* Common */ = {
 			isa = PBXGroup;
 			children = (
+				140B87572987B6E500436F65 /* Base */,
 				B5BA278B2927B08800BDCE08 /* View */,
 			);
 			path = Common;
@@ -2066,12 +2088,14 @@
 				141344D5292F801100187B86 /* TypeConversion.swift in Sources */,
 				141A7A70297E5BDC003DD926 /* ScrapViewModelError.swift in Sources */,
 				D89AE4E82933AF1E00446AB3 /* ImageCacheManager.swift in Sources */,
+				140B87592987B6EF00436F65 /* AppleAuthViewController.swift in Sources */,
 				1459C3BA292910B300FA885D /* RecommendFeedCell.swift in Sources */,
 				1404DA4529825A2E00228E50 /* LoginUseCaseError.swift in Sources */,
 				B50A27E529279F5D00DF3E1F /* LogInView.swift in Sources */,
 				148EF12C29791B0F00190471 /* DefaultImageRepository.swift in Sources */,
 				D8494D4E2927CE64008157F1 /* Domain.swift in Sources */,
 				3B061FDA2928CF7E00BFA71D /* SighUpDomainView.swift in Sources */,
+				140B87562987993300436F65 /* LoginProvider.swift in Sources */,
 				D8494D482927C9E8008157F1 /* MyPageViewModel.swift in Sources */,
 				14A34D3C2974192800501A66 /* GithubAPI.swift in Sources */,
 				14FF7A29298384FB001D6EDF /* MockUpFeedRepository.swift in Sources */,

--- a/burstcamp/burstcamp.xcodeproj/project.pbxproj
+++ b/burstcamp/burstcamp.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		140438C0293F77DD004D035C /* Factory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 140438BF293F77DD004D035C /* Factory.swift */; };
 		1404DA43298259A100228E50 /* UserRepositoryError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1404DA42298259A100228E50 /* UserRepositoryError.swift */; };
 		1404DA4529825A2E00228E50 /* LoginUseCaseError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1404DA4429825A2E00228E50 /* LoginUseCaseError.swift */; };
+		140B8751298775A300436F65 /* String+sha256.swift in Sources */ = {isa = PBXBuildFile; fileRef = 140B8750298775A300436F65 /* String+sha256.swift */; };
 		140E210429443E6300D6E2E5 /* FirestoreService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 140E210329443E6300D6E2E5 /* FirestoreService.swift */; };
 		140E21062944519E00D6E2E5 /* BCFirestoreService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 140E21052944519E00D6E2E5 /* BCFirestoreService.swift */; };
 		140E21092944688B00D6E2E5 /* Future+Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 140E21082944688B00D6E2E5 /* Future+Async.swift */; };
@@ -273,6 +274,7 @@
 		140438BF293F77DD004D035C /* Factory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Factory.swift; sourceTree = "<group>"; };
 		1404DA42298259A100228E50 /* UserRepositoryError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserRepositoryError.swift; sourceTree = "<group>"; };
 		1404DA4429825A2E00228E50 /* LoginUseCaseError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginUseCaseError.swift; sourceTree = "<group>"; };
+		140B8750298775A300436F65 /* String+sha256.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+sha256.swift"; sourceTree = "<group>"; };
 		140E210329443E6300D6E2E5 /* FirestoreService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirestoreService.swift; sourceTree = "<group>"; };
 		140E21052944519E00D6E2E5 /* BCFirestoreService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BCFirestoreService.swift; sourceTree = "<group>"; };
 		140E21082944688B00D6E2E5 /* Future+Async.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Future+Async.swift"; sourceTree = "<group>"; };
@@ -740,6 +742,7 @@
 				141344D2292F801100187B86 /* TypeConversion.swift */,
 				D89AE4F02935AE7800446AB3 /* Encodable+dictionary.swift */,
 				D89AE4F22935AFE100446AB3 /* Notification+.swift */,
+				140B8750298775A300436F65 /* String+sha256.swift */,
 			);
 			path = Type;
 			sourceTree = "<group>";
@@ -1987,6 +1990,7 @@
 				148A05622972F7B900664CCB /* MyPageUseCase.swift in Sources */,
 				B5DAD681292E58BF00C4A126 /* DefaultMultilLineLabel.swift in Sources */,
 				3B061FDD2928E8E300BFA71D /* SignUpCamperIDViewController.swift in Sources */,
+				140B8751298775A300436F65 /* String+sha256.swift in Sources */,
 				145842B4297FF5C800C81878 /* DiffableFeed.swift in Sources */,
 				1496CF1E294070A3008F312F /* ContainFeedDetailCoordinator.swift in Sources */,
 				140438C0293F77DD004D035C /* Factory.swift in Sources */,

--- a/burstcamp/burstcamp/App/SceneDelegate.swift
+++ b/burstcamp/burstcamp/App/SceneDelegate.swift
@@ -28,7 +28,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                   let myPageViewController = tabBarController.children.first(where: {
                       $0 as? MyPageViewController != nil
                   }) as? MyPageViewController {
-            myPageViewController.withDrawalUser(code: code)
+            myPageViewController.withdrawalWithGithub(code: code)
         }
         else { // 탈퇴
             fatalError("로그인, 로그아웃 불가능")

--- a/burstcamp/burstcamp/App/SceneDelegate.swift
+++ b/burstcamp/burstcamp/App/SceneDelegate.swift
@@ -28,7 +28,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                   let myPageViewController = tabBarController.children.first(where: {
                       $0 as? MyPageViewController != nil
                   }) as? MyPageViewController {
-            myPageViewController.withDrawal(code: code)
+            myPageViewController.withDrawalUser(code: code)
         }
         else { // 탈퇴
             fatalError("로그인, 로그아웃 불가능")

--- a/burstcamp/burstcamp/App/SceneDelegate.swift
+++ b/burstcamp/burstcamp/App/SceneDelegate.swift
@@ -23,7 +23,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         appCoordinator.dismissNavigationController()
 
         if let loginViewController = window.rootViewController?.children.first as? LogInViewController { // 로그인
-            loginViewController.login(code: code)
+            loginViewController.loginWithGithub(code: code)
         } else if let tabBarController = window.rootViewController?.children.first as? UITabBarController,
                   let myPageViewController = tabBarController.children.first(where: {
                       $0 as? MyPageViewController != nil

--- a/burstcamp/burstcamp/Data/Repositories/LoginRepository/DefaultLoginRepository.swift
+++ b/burstcamp/burstcamp/Data/Repositories/LoginRepository/DefaultLoginRepository.swift
@@ -44,10 +44,19 @@ final class DefaultLoginRepository: LoginRepository {
 
         KeyChainManager.deleteUser()
         let userUUID = UserManager.shared.user.userUUID
-        // TODO: Listener 제거
         UserManager.shared.removeUserListener()
         UserManager.shared.deleteUserInfo()
         return try await bcFirebaseFunctionService.deleteUser(userUUID: userUUID)
+    }
+
+    /// 애플 로그인
+    /// - Returns: user UUID
+    func loginWithApple(idTokenString: String, nonce: String) async throws -> String {
+        return try await bcFirebaseAuthService.loginWithApple(idTokenString: idTokenString, nonce: nonce)
+    }
+
+    func withdrawalWithApple(idTokenString: String, nonce: String) async throws {
+        try await bcFirebaseAuthService.withdrawalWithApple(idTokenString: idTokenString, nonce: nonce)
     }
 
     private func authorizeBoostcamp(code: String) async throws -> (userNickname: String, token: String) {

--- a/burstcamp/burstcamp/Data/Repositories/LoginRepository/DefaultLoginRepository.swift
+++ b/burstcamp/burstcamp/Data/Repositories/LoginRepository/DefaultLoginRepository.swift
@@ -8,7 +8,6 @@
 import Foundation
 
 final class DefaultLoginRepository: LoginRepository {
-
     private let bcFirebaseAuthService: BCFirebaseAuthService
     private let bcFirebaseFunctionService: BCFirebaseFunctionService
     private let githubLoginDataSource: GithubLoginDatasource
@@ -38,14 +37,10 @@ final class DefaultLoginRepository: LoginRepository {
         return (userNickname, userUUID)
     }
 
-    func withdrawalWithGithub(code: String) async throws -> Bool {
+    func withdrawalWithGithub(code: String, userUUID: String) async throws -> Bool {
         let githubToken = try await githubLoginDataSource.requestGithubToken(code: code)
         try await bcFirebaseAuthService.withdrawalWithGithub(token: githubToken.accessToken)
 
-        KeyChainManager.deleteUser()
-        let userUUID = UserManager.shared.user.userUUID
-        UserManager.shared.removeUserListener()
-        UserManager.shared.deleteUserInfo()
         return try await bcFirebaseFunctionService.deleteUser(userUUID: userUUID)
     }
 
@@ -55,13 +50,8 @@ final class DefaultLoginRepository: LoginRepository {
         return try await bcFirebaseAuthService.loginWithApple(idTokenString: idTokenString, nonce: nonce)
     }
 
-    func withdrawalWithApple(idTokenString: String, nonce: String) async throws -> Bool {
+    func withdrawalWithApple(idTokenString: String, nonce: String, userUUID: String) async throws -> Bool {
         try await bcFirebaseAuthService.withdrawalWithApple(idTokenString: idTokenString, nonce: nonce)
-
-        KeyChainManager.deleteUser()
-        let userUUID = UserManager.shared.user.userUUID
-        UserManager.shared.removeUserListener()
-        UserManager.shared.deleteUserInfo()
         return try await bcFirebaseFunctionService.deleteUser(userUUID: userUUID)
     }
 

--- a/burstcamp/burstcamp/Data/Repositories/UserRepository/DefaultUserRepository.swift
+++ b/burstcamp/burstcamp/Data/Repositories/UserRepository/DefaultUserRepository.swift
@@ -70,4 +70,17 @@ final class DefaultUserRepository: UserRepository {
             isPushOn: user.isPushOn
         )
     }
+
+    // MARK: Guest
+    func saveGuest(userUUID: String) async throws {
+        let nickname = try getNickname(userUUID: userUUID)
+        let guestUser = User(userUUID: userUUID, nickname: nickname)
+        let guestUserAPIModel = userToAPIModel(guestUser)
+        try await bcFirestoreService.saveUser(userUUID: guestUser.userUUID, user: guestUserAPIModel)
+    }
+
+    private func getNickname(userUUID: String) throws -> String {
+        if userUUID.count < 6 { throw UserRepositoryError.createGuestID }
+        return "Guest-" + String(userUUID.prefix(6))
+    }
 }

--- a/burstcamp/burstcamp/Data/Repositories/UserRepository/DefaultUserRepository.swift
+++ b/burstcamp/burstcamp/Data/Repositories/UserRepository/DefaultUserRepository.swift
@@ -72,11 +72,12 @@ final class DefaultUserRepository: UserRepository {
     }
 
     // MARK: Guest
-    func saveGuest(userUUID: String) async throws {
+    func saveGuest(userUUID: String) async throws -> User {
         let nickname = try getNickname(userUUID: userUUID)
         let guestUser = User(userUUID: userUUID, nickname: nickname)
         let guestUserAPIModel = userToAPIModel(guestUser)
         try await bcFirestoreService.saveUser(userUUID: guestUser.userUUID, user: guestUserAPIModel)
+        return guestUser
     }
 
     private func getNickname(userUUID: String) throws -> String {

--- a/burstcamp/burstcamp/Domain/Interfaces/LoginRepository/LoginRepository.swift
+++ b/burstcamp/burstcamp/Domain/Interfaces/LoginRepository/LoginRepository.swift
@@ -11,8 +11,8 @@ protocol LoginRepository {
     func isLoggedIn() -> Bool
 
     func loginWithGithub(code: String) async throws -> (userNickname: String, userUUID: String)
-    func withdrawalWithGithub(code: String) async throws -> Bool
+    func withdrawalWithGithub(code: String, userUUID: String) async throws -> Bool
 
     func loginWithApple(idTokenString: String, nonce: String) async throws -> String
-    func withdrawalWithApple(idTokenString: String, nonce: String) async throws -> Bool
+    func withdrawalWithApple(idTokenString: String, nonce: String, userUUID: String) async throws -> Bool
 }

--- a/burstcamp/burstcamp/Domain/Interfaces/LoginRepository/LoginRepository.swift
+++ b/burstcamp/burstcamp/Domain/Interfaces/LoginRepository/LoginRepository.swift
@@ -11,4 +11,6 @@ protocol LoginRepository {
     func isLoggedIn() -> Bool
     func login(code: String) async throws -> (userNickname: String, userUUID: String)
     func withdrawal(code: String) async throws -> Bool
+    func loginWithApple(idTokenString: String, nonce: String) async throws -> String
+    func withdrawalWithApple(idTokenString: String, nonce: String) async throws
 }

--- a/burstcamp/burstcamp/Domain/Interfaces/LoginRepository/LoginRepository.swift
+++ b/burstcamp/burstcamp/Domain/Interfaces/LoginRepository/LoginRepository.swift
@@ -9,8 +9,10 @@ import Foundation
 
 protocol LoginRepository {
     func isLoggedIn() -> Bool
-    func login(code: String) async throws -> (userNickname: String, userUUID: String)
-    func withdrawal(code: String) async throws -> Bool
+
+    func loginWithGithub(code: String) async throws -> (userNickname: String, userUUID: String)
+    func withdrawalWithGithub(code: String) async throws -> Bool
+
     func loginWithApple(idTokenString: String, nonce: String) async throws -> String
-    func withdrawalWithApple(idTokenString: String, nonce: String) async throws
+    func withdrawalWithApple(idTokenString: String, nonce: String) async throws -> Bool
 }

--- a/burstcamp/burstcamp/Domain/Interfaces/UserRepository/UserRepository.swift
+++ b/burstcamp/burstcamp/Domain/Interfaces/UserRepository/UserRepository.swift
@@ -14,4 +14,6 @@ protocol UserRepository {
     func updateUserPushState(userUUID: String, isPushOn: Bool) async throws
     func removeUser(_ user: User) async throws
     func saveFCMToken(_ token: String, to userUUID: String) async throws
+
+    func saveGuest(userUUID: String) async throws
 }

--- a/burstcamp/burstcamp/Domain/Interfaces/UserRepository/UserRepository.swift
+++ b/burstcamp/burstcamp/Domain/Interfaces/UserRepository/UserRepository.swift
@@ -15,5 +15,5 @@ protocol UserRepository {
     func removeUser(_ user: User) async throws
     func saveFCMToken(_ token: String, to userUUID: String) async throws
 
-    func saveGuest(userUUID: String) async throws
+    func saveGuest(userUUID: String) async throws -> User
 }

--- a/burstcamp/burstcamp/Domain/Model/User/Domain.swift
+++ b/burstcamp/burstcamp/Domain/Model/User/Domain.swift
@@ -13,12 +13,14 @@ enum Domain: String, Codable, PersistableEnum {
     case iOS = "iOS"
     case android = "Android"
     case web = "Web"
+    case guest = "Guest"
 
     var color: UIColor {
         switch self {
         case .iOS: return UIColor.customOrange
         case .android: return UIColor.customGreen
         case .web: return UIColor.customYellow
+        case .guest: return UIColor.systemGray
         }
     }
 
@@ -27,6 +29,7 @@ enum Domain: String, Codable, PersistableEnum {
         case .iOS: return UIColor.brightOrange
         case .android: return UIColor.brightGreen
         case .web: return UIColor.brightYellow
+        case .guest: return UIColor.systemGray
         }
     }
 
@@ -35,6 +38,7 @@ enum Domain: String, Codable, PersistableEnum {
         case .iOS: return "S"
         case .android: return "K"
         case .web: return "J"
+        case .guest: return "Guest"
         }
     }
 }

--- a/burstcamp/burstcamp/Domain/Model/User/Login/LoginProvider.swift
+++ b/burstcamp/burstcamp/Domain/Model/User/Login/LoginProvider.swift
@@ -1,0 +1,22 @@
+//
+//  LoginProviderID.swift
+//  burstcamp
+//
+//  Created by youtak on 2023/01/30.
+//
+
+import Foundation
+
+enum LoginProvider {
+    case github
+    case apple
+}
+
+extension LoginProvider {
+    var id: String {
+        switch self {
+        case .github: return "github.com"
+        case .apple: return "apple.com"
+        }
+    }
+}

--- a/burstcamp/burstcamp/Domain/Model/User/User.swift
+++ b/burstcamp/burstcamp/Domain/Model/User/User.swift
@@ -38,8 +38,8 @@ extension User {
         self.userUUID = dictionary["userUUID"] as? String ?? ""
         self.nickname = dictionary["nickname"] as? String ?? ""
         self.profileImageURL = dictionary["profileImageURL"] as? String ?? ""
-        let domainString = dictionary["domain"] as? String ?? "iOS"
-        self.domain = Domain(rawValue: domainString) ?? .iOS
+        let domainString = dictionary["domain"] as? String ?? ""
+        self.domain = Domain(rawValue: domainString) ?? .guest
         self.camperID = dictionary["camperID"] as? String ?? ""
         self.ordinalNumber = dictionary["ordinalNumber"] as? Int ?? 7
         self.blogURL = dictionary["blogURL"] as? String ?? ""

--- a/burstcamp/burstcamp/Domain/Model/User/User.swift
+++ b/burstcamp/burstcamp/Domain/Model/User/User.swift
@@ -85,6 +85,24 @@ extension User {
         self.isPushOn = userAPIModel.isPushOn
     }
 
+    /// Guest 생성을 위한 이니셜라이저
+    /// - Parameters:
+    ///   - userUUID: 로그인을 통해 얻은 userUUID
+    ///   - nickname: 게스트 닉네임
+    init (userUUID: String, nickname: String) {
+        self.userUUID = userUUID
+        self.nickname = nickname
+        self.profileImageURL = ""
+        self.domain = .guest
+        self.camperID = ""
+        self.ordinalNumber = 7
+        self.blogURL = ""
+        self.blogTitle = ""
+        self.scrapFeedUUIDs = []
+        self.signupDate = Date()
+        self.isPushOn = false
+    }
+
     var toFeedWriter: FeedWriter {
         return FeedWriter(
             userUUID: self.userUUID,

--- a/burstcamp/burstcamp/Domain/UseCase/Auth/Login/DefaultLoginUseCase.swift
+++ b/burstcamp/burstcamp/Domain/UseCase/Auth/Login/DefaultLoginUseCase.swift
@@ -39,4 +39,12 @@ final class DefaultLoginUseCase: LoginUseCase {
     func login(code: String) async throws ->  (userNickname: String, userUUID: String) {
         return try await loginRepository.login(code: code)
     }
+
+    func loginWithApple(idTokenString: String, nonce: String) async throws -> String {
+        return try await loginRepository.loginWithApple(idTokenString: idTokenString, nonce: nonce)
+    }
+
+    func withdrawalWithApple(idTokenString: String, nonce: String) async throws {
+        try await loginRepository.withdrawalWithApple(idTokenString: idTokenString, nonce: nonce)
+    }
 }

--- a/burstcamp/burstcamp/Domain/UseCase/Auth/Login/DefaultLoginUseCase.swift
+++ b/burstcamp/burstcamp/Domain/UseCase/Auth/Login/DefaultLoginUseCase.swift
@@ -36,8 +36,8 @@ final class DefaultLoginUseCase: LoginUseCase {
         return loginRepository.isLoggedIn() && KeyChainManager.readUser() != nil
     }
 
-    func login(code: String) async throws ->  (userNickname: String, userUUID: String) {
-        return try await loginRepository.login(code: code)
+    func loginWithGithub(code: String) async throws -> (userNickname: String, userUUID: String) {
+        return try await loginRepository.loginWithGithub(code: code)
     }
 
     func loginWithApple(idTokenString: String, nonce: String) async throws -> String {

--- a/burstcamp/burstcamp/Domain/UseCase/Auth/Login/DefaultLoginUseCase.swift
+++ b/burstcamp/burstcamp/Domain/UseCase/Auth/Login/DefaultLoginUseCase.swift
@@ -45,6 +45,7 @@ final class DefaultLoginUseCase: LoginUseCase {
     }
 
     func createGuest(userUUID: String) async throws {
-        try await userRepository.saveGuest(userUUID: userUUID)
+        let guestUser = try await userRepository.saveGuest(userUUID: userUUID)
+        UserManager.shared.setUser(guestUser)
     }
 }

--- a/burstcamp/burstcamp/Domain/UseCase/Auth/Login/DefaultLoginUseCase.swift
+++ b/burstcamp/burstcamp/Domain/UseCase/Auth/Login/DefaultLoginUseCase.swift
@@ -44,7 +44,7 @@ final class DefaultLoginUseCase: LoginUseCase {
         return try await loginRepository.loginWithApple(idTokenString: idTokenString, nonce: nonce)
     }
 
-    func withdrawalWithApple(idTokenString: String, nonce: String) async throws {
-        try await loginRepository.withdrawalWithApple(idTokenString: idTokenString, nonce: nonce)
+    func createGuest(userUUID: String) async throws {
+        try await userRepository.saveGuest(userUUID: userUUID)
     }
 }

--- a/burstcamp/burstcamp/Domain/UseCase/Auth/Login/LoginUseCase.swift
+++ b/burstcamp/burstcamp/Domain/UseCase/Auth/Login/LoginUseCase.swift
@@ -10,7 +10,9 @@ import Foundation
 protocol LoginUseCase {
     func checkIsExist(userUUID: String) async throws -> Bool
     func isLoggedIn() -> Bool
-    func login(code: String) async throws -> (userNickname: String, userUUID: String)
+
+    func loginWithGithub(code: String) async throws -> (userNickname: String, userUUID: String)
+
     func loginWithApple(idTokenString: String, nonce: String) async throws -> String
     func withdrawalWithApple(idTokenString: String, nonce: String) async throws
 }

--- a/burstcamp/burstcamp/Domain/UseCase/Auth/Login/LoginUseCase.swift
+++ b/burstcamp/burstcamp/Domain/UseCase/Auth/Login/LoginUseCase.swift
@@ -10,5 +10,7 @@ import Foundation
 protocol LoginUseCase {
     func checkIsExist(userUUID: String) async throws -> Bool
     func isLoggedIn() -> Bool
-    func login(code: String) async throws ->  (userNickname: String, userUUID: String)
+    func login(code: String) async throws -> (userNickname: String, userUUID: String)
+    func loginWithApple(idTokenString: String, nonce: String) async throws -> String
+    func withdrawalWithApple(idTokenString: String, nonce: String) async throws
 }

--- a/burstcamp/burstcamp/Domain/UseCase/Auth/Login/LoginUseCase.swift
+++ b/burstcamp/burstcamp/Domain/UseCase/Auth/Login/LoginUseCase.swift
@@ -14,5 +14,6 @@ protocol LoginUseCase {
     func loginWithGithub(code: String) async throws -> (userNickname: String, userUUID: String)
 
     func loginWithApple(idTokenString: String, nonce: String) async throws -> String
-    func withdrawalWithApple(idTokenString: String, nonce: String) async throws
+
+    func createGuest(userUUID: String) async throws
 }

--- a/burstcamp/burstcamp/Domain/UseCase/Tab/MyPage/DefaultMyPageUseCase.swift
+++ b/burstcamp/burstcamp/Domain/UseCase/Tab/MyPage/DefaultMyPageUseCase.swift
@@ -20,7 +20,7 @@ final class DefaultMyPageUseCase: MyPageUseCase {
     }
 
     func withdrawal(code: String, userUUID: String) async throws {
-        let isSuccess = try await loginRepository.withdrawal(code: code)
+        let isSuccess = try await loginRepository.withdrawalWithGithub(code: code)
         try await imageRepository.deleteProfileImage(userUUID: userUUID)
         if !isSuccess { throw MyPageUseCaseError.withdrawal }
     }

--- a/burstcamp/burstcamp/Domain/UseCase/Tab/MyPage/DefaultMyPageUseCase.swift
+++ b/burstcamp/burstcamp/Domain/UseCase/Tab/MyPage/DefaultMyPageUseCase.swift
@@ -19,10 +19,14 @@ final class DefaultMyPageUseCase: MyPageUseCase {
         self.imageRepository = imageRepository
     }
 
-    func withdrawal(code: String, userUUID: String) async throws {
+    func withdrawalWithGithub(code: String, userUUID: String) async throws {
         let isSuccess = try await loginRepository.withdrawalWithGithub(code: code)
         try await imageRepository.deleteProfileImage(userUUID: userUUID)
+        KeyChainManager.deleteUser()
         if !isSuccess { throw MyPageUseCaseError.withdrawal }
+    }
+
+    func withdrawalWithApple() async throws {
     }
 
     func updateUserPushState(userUUID: String, isPushOn: Bool) async throws {

--- a/burstcamp/burstcamp/Domain/UseCase/Tab/MyPage/MyPageUseCase.swift
+++ b/burstcamp/burstcamp/Domain/UseCase/Tab/MyPage/MyPageUseCase.swift
@@ -8,7 +8,9 @@
 import Foundation
 
 protocol MyPageUseCase {
-    func withdrawalWithGithub(code: String, userUUID: String) async throws
+    func withdrawalWithGithub(code: String) async throws
+    func withdrawalWithApple(idTokenString: String, nonce: String) async throws
+
     func updateUserPushState(userUUID: String, isPushOn: Bool) async throws
     func updateUserDarkModeState(appearance: Appearance)
     func updateLocalUser(_ user: User)

--- a/burstcamp/burstcamp/Domain/UseCase/Tab/MyPage/MyPageUseCase.swift
+++ b/burstcamp/burstcamp/Domain/UseCase/Tab/MyPage/MyPageUseCase.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 protocol MyPageUseCase {
-    func withdrawal(code: String, userUUID: String) async throws
+    func withdrawalWithGithub(code: String, userUUID: String) async throws
     func updateUserPushState(userUUID: String, isPushOn: Bool) async throws
     func updateUserDarkModeState(appearance: Appearance)
     func updateLocalUser(_ user: User)

--- a/burstcamp/burstcamp/Presentation/Auth/LogIn/View/LogInView.swift
+++ b/burstcamp/burstcamp/Presentation/Auth/LogIn/View/LogInView.swift
@@ -28,7 +28,12 @@ final class LogInView: UIView {
         $0.font = UIFont.regular14
     }
 
-    let camperAuthButton = AuthButton(text: "Github으로 캠퍼 로그인", image: .github)
+    let appleAuthButton = AuthButton(
+        text: "Apple로 로그인",
+        image: UIImage(systemName: "apple.logo")?.withTintColor(UIColor.dynamicWhite, renderingMode: .alwaysOriginal)
+    )
+
+    let camperAuthButton = AuthButton(text: "Github으로 로그인", image: .github)
 
     private lazy var camperAuthLabel: UILabel = UILabel().then {
         $0.text = "Github 로그인을 통해 캠퍼인증을 하고 내 글을 등록할 수 있어요."
@@ -67,6 +72,7 @@ final class LogInView: UIView {
         addSubview(titleImage)
         addSubview(titleLabel)
         addSubview(identitySentenceLabel)
+        addSubview(appleAuthButton)
         addSubview(camperAuthButton)
         addSubview(camperAuthLabel)
         addSubview(activityIndicator)
@@ -96,13 +102,10 @@ final class LogInView: UIView {
             $0.bottom.equalToSuperview().multipliedBy(0.9)
         }
 
-        camperAuthButton.imageView?.snp.makeConstraints {
-            $0.trailing.equalToSuperview().multipliedBy(0.15)
-            $0.centerY.equalToSuperview()
-        }
-
-        camperAuthButton.titleLabel?.snp.makeConstraints {
-            $0.center.equalToSuperview()
+        appleAuthButton.snp.makeConstraints {
+            $0.horizontalEdges.equalToSuperview().inset(Constant.space16)
+            $0.height.equalTo(Constant.Button.camperAuthButtonHeight)
+            $0.bottom.equalTo(camperAuthButton.snp.top).offset(-Constant.space12)
         }
 
         camperAuthLabel.snp.makeConstraints {

--- a/burstcamp/burstcamp/Presentation/Auth/LogIn/View/LogInView.swift
+++ b/burstcamp/burstcamp/Presentation/Auth/LogIn/View/LogInView.swift
@@ -5,6 +5,7 @@
 //  Created by 김기훈 on 2022/11/18.
 //
 
+import AuthenticationServices
 import UIKit
 
 import SnapKit
@@ -27,45 +28,10 @@ final class LogInView: UIView {
         $0.font = UIFont.regular14
     }
 
-    lazy var camperAuthButton: UIButton = {
-        let button = UIButton()
-
-        if #available(iOS 15.0, *) {
-            var string = AttributedString("캠퍼 인증 시작하기")
-            string.font = UIFont.extraBold14
-            string.foregroundColor = .dynamicWhite
-
-            var configuration = UIButton.Configuration.filled()
-            configuration.attributedTitle = string
-            configuration.titleAlignment = .center
-
-            configuration.image = UIImage.github
-            configuration.imagePlacement = .leading
-            configuration.imagePadding = 50
-
-            configuration.baseBackgroundColor = .dynamicBlack
-            configuration.cornerStyle = .medium
-
-            button.configuration = configuration
-
-            return button
-        } else {
-            button.setTitle("캠퍼 인증 시작하기", for: .normal)
-            button.titleLabel?.font = UIFont.extraBold14
-            button.setTitleColor(.dynamicWhite, for: .normal)
-            button.titleLabel?.textAlignment = .center
-
-            button.setImage(UIImage.github, for: .normal)
-
-            button.backgroundColor = .dynamicBlack
-            button.layer.cornerRadius = CGFloat(Constant.CornerRadius.radius8)
-
-            return button
-        }
-    }()
+    let camperAuthButton = AuthButton(text: "Github으로 캠퍼 로그인", image: .github)
 
     private lazy var camperAuthLabel: UILabel = UILabel().then {
-        $0.text = "캠퍼 인증을 위해 Github으로 로그인을 해주세요."
+        $0.text = "Github 로그인을 통해 캠퍼인증을 하고 내 글을 등록할 수 있어요."
         $0.font = UIFont.regular12
         $0.textColor = .systemGray2
     }

--- a/burstcamp/burstcamp/Presentation/Auth/LogIn/ViewController/LogInViewController.swift
+++ b/burstcamp/burstcamp/Presentation/Auth/LogIn/ViewController/LogInViewController.swift
@@ -43,6 +43,8 @@ final class LogInViewController: AppleAuthViewController {
         bind()
     }
 
+    // TODO: 인자 받아서 label 분기 처리
+
     func showIndicator() {
         DispatchQueue.main.async {
             self.logInView.activityIndicator.startAnimating()
@@ -107,6 +109,7 @@ final class LogInViewController: AppleAuthViewController {
             .store(in: &cancelBag)
 
         // MARK: - Apple 로그인
+
         logInView.appleAuthButton.tapPublisher
             .sink { [weak self] _ in
                 self?.startSignInWithAppleFlow()

--- a/burstcamp/burstcamp/Presentation/Auth/LogIn/ViewController/LogInViewController.swift
+++ b/burstcamp/burstcamp/Presentation/Auth/LogIn/ViewController/LogInViewController.swift
@@ -13,14 +13,12 @@ import UIKit
 import SnapKit
 import Then
 
-final class LogInViewController: UIViewController {
+final class LogInViewController: AppleAuthViewController {
 
     private var logInView: LogInView {
         guard let view = view as? LogInView else { return LogInView() }
         return view
     }
-
-    private var currentNonce: String?
 
     var coordinatorPublisher = PassthroughSubject<AuthCoordinatorEvent, Never>()
     private var cancelBag = Set<AnyCancellable>()
@@ -129,16 +127,9 @@ final class LogInViewController: UIViewController {
     }
 }
 
-extension LogInViewController: ASAuthorizationControllerPresentationContextProviding,
-                                ASAuthorizationControllerDelegate {
-
-    func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
-        guard let window = self.view.window else { fatalError("애플 로그인 ASPresentationAnchor 에러")}
-        return window
-    }
-
+extension LogInViewController: ASAuthorizationControllerDelegate {
     func startSignInWithAppleFlow() {
-        let request = viewModel.getAppleLoginRequest()
+        let request = getAppleLoginRequest()
 
         let authorizationController = ASAuthorizationController(authorizationRequests: [request])
         authorizationController.delegate = self
@@ -151,7 +142,7 @@ extension LogInViewController: ASAuthorizationControllerPresentationContextProvi
         didCompleteWithAuthorization authorization: ASAuthorization
     ) {
         if let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential {
-            guard let nonce = viewModel.currentNonce else {
+            guard let nonce = currentNonce else {
                 fatalError("Invalid state: A login callback was received, but no login request was sent.")
             }
 

--- a/burstcamp/burstcamp/Presentation/Auth/LogIn/ViewController/LogInViewController.swift
+++ b/burstcamp/burstcamp/Presentation/Auth/LogIn/ViewController/LogInViewController.swift
@@ -43,13 +43,11 @@ final class LogInViewController: AppleAuthViewController {
         bind()
     }
 
-    // TODO: 인자 받아서 label 분기 처리
-
-    func showIndicator() {
+    func showIndicator(text: String = "") {
         DispatchQueue.main.async {
             self.logInView.activityIndicator.startAnimating()
             self.logInView.loadingLabel.isHidden = false
-            self.logInView.camperAuthButton.isEnabled = false
+            self.logInView.loadingLabel.text = text
             self.setUserInteraction(isEnabled: false)
         }
     }
@@ -58,14 +56,13 @@ final class LogInViewController: AppleAuthViewController {
         DispatchQueue.main.async {
             self.logInView.activityIndicator.stopAnimating()
             self.logInView.loadingLabel.isHidden = true
-            self.logInView.camperAuthButton.isEnabled = true
             self.setUserInteraction(isEnabled: true)
         }
     }
 
     func loginWithGithub(code: String) {
         Task { [weak self] in
-            self?.showIndicator()
+            self?.showIndicator(text: "캠퍼 인증 중이에요")
             do {
                 try await self?.viewModel.loginWithGithub(code: code)
             } catch {
@@ -119,7 +116,7 @@ final class LogInViewController: AppleAuthViewController {
 
     private func loginWithApple(idTokenString: String, nonce: String) {
         Task { [weak self] in
-            self?.showIndicator()
+            self?.showIndicator(text: "로그인 중이에요")
             do {
                 try await self?.viewModel.loginWithApple(idTokenString: idTokenString, nonce: nonce)
             } catch {

--- a/burstcamp/burstcamp/Presentation/Auth/LogIn/ViewController/LogInViewController.swift
+++ b/burstcamp/burstcamp/Presentation/Auth/LogIn/ViewController/LogInViewController.swift
@@ -63,11 +63,11 @@ final class LogInViewController: UIViewController {
         }
     }
 
-    func login(code: String) {
+    func loginWithGithub(code: String) {
         Task { [weak self] in
             self?.showIndicator()
             do {
-                try await self?.viewModel.login(code: code)
+                try await self?.viewModel.loginWithGithub(code: code)
             } catch {
                 self?.showAlert(message: error.localizedDescription)
             }
@@ -110,13 +110,13 @@ final class LogInViewController: UIViewController {
 
     private func loginWithApple(idTokenString: String, nonce: String) {
         Task { [weak self] in
+            self?.showIndicator()
             do {
-                self?.showIndicator()
                 try await self?.viewModel.loginWithApple(idTokenString: idTokenString, nonce: nonce)
-                self?.hideIndicator()
             } catch {
                 self?.showAlert(message: "애플 로그인에 실패했습니다. \(error.localizedDescription)")
             }
+            self?.hideIndicator()
         }
     }
 }

--- a/burstcamp/burstcamp/Presentation/Auth/LogIn/ViewController/LogInViewController.swift
+++ b/burstcamp/burstcamp/Presentation/Auth/LogIn/ViewController/LogInViewController.swift
@@ -76,6 +76,7 @@ final class LogInViewController: UIViewController {
     }
 
     private func bind() {
+
         let input = LogInViewModel.Input(
             logInButtonDidTap: logInView.camperAuthButton.tapPublisher
         )

--- a/burstcamp/burstcamp/Presentation/Auth/LogIn/ViewController/LogInViewController.swift
+++ b/burstcamp/burstcamp/Presentation/Auth/LogIn/ViewController/LogInViewController.swift
@@ -5,6 +5,7 @@
 //  Created by youtak on 2022/11/15.
 //
 
+import AuthenticationServices
 import Combine
 import SafariServices
 import UIKit
@@ -18,6 +19,8 @@ final class LogInViewController: UIViewController {
         guard let view = view as? LogInView else { return LogInView() }
         return view
     }
+
+    private var currentNonce: String?
 
     var coordinatorPublisher = PassthroughSubject<AuthCoordinatorEvent, Never>()
     private var cancelBag = Set<AnyCancellable>()
@@ -103,5 +106,97 @@ final class LogInViewController: UIViewController {
                 }
             }
             .store(in: &cancelBag)
+    }
+
+    private func loginWithApple(idTokenString: String, nonce: String) {
+        Task { [weak self] in
+            do {
+                self?.showIndicator()
+                try await self?.viewModel.loginWithApple(idTokenString: idTokenString, nonce: nonce)
+                self?.hideIndicator()
+            } catch {
+                self?.showAlert(message: "애플 로그인에 실패했습니다. \(error.localizedDescription)")
+            }
+        }
+    }
+}
+
+extension LogInViewController: ASAuthorizationControllerPresentationContextProviding,
+                                ASAuthorizationControllerDelegate {
+
+    func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+        return self.view.window!
+    }
+
+    func startSignInWithAppleFlow() {
+        let nonce = randomNonceString()
+        currentNonce = nonce
+        let appleIDProvider = ASAuthorizationAppleIDProvider()
+        let request = appleIDProvider.createRequest()
+        request.requestedScopes = [.fullName, .email]
+        request.nonce = nonce.sha256()
+
+        let authorizationController = ASAuthorizationController(authorizationRequests: [request])
+        authorizationController.delegate = self
+        authorizationController.presentationContextProvider = self
+        authorizationController.performRequests()
+    }
+
+    func authorizationController(
+        controller: ASAuthorizationController,
+        didCompleteWithAuthorization authorization: ASAuthorization
+    ) {
+
+        if let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential {
+            guard let nonce = currentNonce else {
+                fatalError("Invalid state: A login callback was received, but no login request was sent.")
+            }
+
+            guard let appleIDToken = appleIDCredential.identityToken else {
+                print("Unable to fetch identity token")
+                return
+            }
+
+            guard let idTokenString = String(data: appleIDToken, encoding: .utf8) else {
+                print("Unable to serialize token string from data: \(appleIDToken.debugDescription)")
+                return
+            }
+
+            loginWithApple(idTokenString: idTokenString, nonce: nonce)
+        }
+    }
+
+    private func randomNonceString(length: Int = 32) -> String {
+      precondition(length > 0)
+      let charset: [Character] =
+        Array("0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._")
+      var result = ""
+      var remainingLength = length
+
+      while remainingLength > 0 {
+        let randoms: [UInt8] = (0 ..< 16).map { _ in
+          var random: UInt8 = 0
+          let errorCode = SecRandomCopyBytes(kSecRandomDefault, 1, &random)
+          if errorCode != errSecSuccess {
+            fatalError(
+              "Unable to generate nonce. SecRandomCopyBytes failed with OSStatus \(errorCode)"
+            )
+          }
+          return random
+        }
+
+        randoms.forEach { random in
+          if remainingLength == 0 {
+            return
+          }
+
+          if random < charset.count {
+            result.append(charset[Int(random)])
+            remainingLength -= 1
+          }
+        }
+      }
+
+      return result
     }
 }

--- a/burstcamp/burstcamp/Presentation/Auth/LogIn/ViewModel/LogInViewModel.swift
+++ b/burstcamp/burstcamp/Presentation/Auth/LogIn/ViewModel/LogInViewModel.swift
@@ -41,8 +41,8 @@ final class LogInViewModel {
         )
     }
 
-    func login(code: String) async throws {
-        let (userNickname, userUUID) = try await loginUseCase.login(code: code)
+    func loginWithGithub(code: String) async throws {
+        let (userNickname, userUUID) = try await loginUseCase.loginWithGithub(code: code)
         UserManager.shared.setUserUUID(userUUID)
 
         let isUserExist = try await loginUseCase.checkIsExist(userUUID: userUUID)

--- a/burstcamp/burstcamp/Presentation/Auth/LogIn/ViewModel/LogInViewModel.swift
+++ b/burstcamp/burstcamp/Presentation/Auth/LogIn/ViewModel/LogInViewModel.swift
@@ -52,4 +52,16 @@ final class LogInViewModel {
             logInPublisher.send(.moveToDomainScreen(userNickname: userNickname))
         }
     }
+
+    func loginWithApple(idTokenString: String, nonce: String) async throws {
+        let userUUID = try await loginUseCase.loginWithApple(idTokenString: idTokenString, nonce: nonce)
+        UserManager.shared.setUserUUID(userUUID)
+
+        let isUserExist = try await loginUseCase.checkIsExist(userUUID: userUUID)
+        if isUserExist {
+            logInPublisher.send(.moveToTabBarScreen)
+        } else {
+            // Guest로 계정 생성
+        }
+    }
 }

--- a/burstcamp/burstcamp/Presentation/Auth/LogIn/ViewModel/LogInViewModel.swift
+++ b/burstcamp/burstcamp/Presentation/Auth/LogIn/ViewModel/LogInViewModel.swift
@@ -46,6 +46,7 @@ final class LogInViewModel {
     func loginWithGithub(code: String) async throws {
         let (userNickname, userUUID) = try await loginUseCase.loginWithGithub(code: code)
         UserManager.shared.setUserUUID(userUUID)
+        UserManager.shared.addUserListener()
 
         let isUserExist = try await loginUseCase.checkIsExist(userUUID: userUUID)
         if isUserExist {
@@ -63,6 +64,7 @@ final class LogInViewModel {
         if !isUserExist {
             try await loginUseCase.createGuest(userUUID: userUUID)
         }
+        UserManager.shared.addUserListener()
         logInPublisher.send(.moveToTabBarScreen)
     }
 }

--- a/burstcamp/burstcamp/Presentation/Auth/LogIn/ViewModel/LogInViewModel.swift
+++ b/burstcamp/burstcamp/Presentation/Auth/LogIn/ViewModel/LogInViewModel.swift
@@ -13,8 +13,6 @@ final class LogInViewModel {
 
     private let loginUseCase: LoginUseCase
 
-    private(set) var currentNonce: String?
-
     private var logInPublisher = PassthroughSubject<AuthCoordinatorEvent, Never>()
 
     init(loginUseCase: LoginUseCase) {
@@ -66,18 +64,5 @@ final class LogInViewModel {
             try await loginUseCase.createGuest(userUUID: userUUID)
         }
         logInPublisher.send(.moveToTabBarScreen)
-    }
-}
-
-extension LogInViewModel {
-    func getAppleLoginRequest() -> ASAuthorizationAppleIDRequest {
-        let nonce = String.randomNonceString()
-        currentNonce = nonce
-        let appleIDProvider = ASAuthorizationAppleIDProvider()
-        let request = appleIDProvider.createRequest()
-        request.requestedScopes = [.fullName, .email]
-        request.nonce = nonce.sha256()
-
-        return request
     }
 }

--- a/burstcamp/burstcamp/Presentation/Common/Base/AppleAuthViewController.swift
+++ b/burstcamp/burstcamp/Presentation/Common/Base/AppleAuthViewController.swift
@@ -1,0 +1,36 @@
+//
+//  AppleAuthViewController.swift
+//  burstcamp
+//
+//  Created by youtak on 2023/01/30.
+//
+
+import AuthenticationServices
+import UIKit
+
+struct AppleLoginInfo {
+    let nonce: String
+    let idTokenString: String
+}
+
+class AppleAuthViewController: UIViewController,
+                                ASAuthorizationControllerPresentationContextProviding {
+
+    private(set) var currentNonce: String?
+
+    func getAppleLoginRequest() -> ASAuthorizationAppleIDRequest {
+        let nonce = String.randomNonceString()
+        currentNonce = nonce
+        let appleIDProvider = ASAuthorizationAppleIDProvider()
+        let request = appleIDProvider.createRequest()
+        request.requestedScopes = [.fullName, .email]
+        request.nonce = nonce.sha256()
+
+        return request
+    }
+
+    func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+        guard let window = self.view.window else { fatalError("애플 로그인 ASPresentationAnchor 에러")}
+        return window
+    }
+}

--- a/burstcamp/burstcamp/Presentation/Common/Base/AppleAuthViewController.swift
+++ b/burstcamp/burstcamp/Presentation/Common/Base/AppleAuthViewController.swift
@@ -8,11 +8,6 @@
 import AuthenticationServices
 import UIKit
 
-struct AppleLoginInfo {
-    let nonce: String
-    let idTokenString: String
-}
-
 class AppleAuthViewController: UIViewController,
                                 ASAuthorizationControllerPresentationContextProviding {
 

--- a/burstcamp/burstcamp/Presentation/Common/View/Button/AuthButton.swift
+++ b/burstcamp/burstcamp/Presentation/Common/View/Button/AuthButton.swift
@@ -11,7 +11,7 @@ final class AuthButton: UIButton {
 
     init(
         text: String,
-        image: UIImage
+        image: UIImage?
     ) {
         super.init(frame: .zero)
 
@@ -25,10 +25,12 @@ final class AuthButton: UIButton {
 
         configuration.image = image
         configuration.imagePlacement = .leading
-        configuration.imagePadding = 50
+        configuration.imagePadding = 20
 
         configuration.baseBackgroundColor = .dynamicBlack
         configuration.cornerStyle = .medium
+
+        configuration.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 20)
 
         self.configuration = configuration
     }

--- a/burstcamp/burstcamp/Presentation/Common/View/Button/AuthButton.swift
+++ b/burstcamp/burstcamp/Presentation/Common/View/Button/AuthButton.swift
@@ -1,0 +1,39 @@
+//
+//  AuthButton.swift
+//  burstcamp
+//
+//  Created by youtak on 2023/01/30.
+//
+
+import UIKit
+
+final class AuthButton: UIButton {
+
+    init(
+        text: String,
+        image: UIImage
+    ) {
+        super.init(frame: .zero)
+
+        var string = AttributedString(text)
+        string.font = UIFont.extraBold14
+        string.foregroundColor = .dynamicWhite
+
+        var configuration = UIButton.Configuration.filled()
+        configuration.attributedTitle = string
+        configuration.titleAlignment = .center
+
+        configuration.image = image
+        configuration.imagePlacement = .leading
+        configuration.imagePadding = 50
+
+        configuration.baseBackgroundColor = .dynamicBlack
+        configuration.cornerStyle = .medium
+
+        self.configuration = configuration
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/burstcamp/burstcamp/Presentation/Common/View/ImageView/DefaultProfileImageView.swift
+++ b/burstcamp/burstcamp/Presentation/Common/View/ImageView/DefaultProfileImageView.swift
@@ -18,7 +18,7 @@ final class DefaultProfileImageView: UIImageView {
         clipsToBounds = true
         image = UIImage(systemName: "person.fill")?.withTintColor(.white, renderingMode: .alwaysOriginal)
         contentMode = .scaleAspectFill
-        backgroundColor = .systemGray2
+        backgroundColor = .systemGray5
     }
 
     required init?(coder: NSCoder) {

--- a/burstcamp/burstcamp/Presentation/Common/View/ImageView/DefaultProfileImageView.swift
+++ b/burstcamp/burstcamp/Presentation/Common/View/ImageView/DefaultProfileImageView.swift
@@ -16,7 +16,7 @@ final class DefaultProfileImageView: UIImageView {
         super.init(frame: .zero)
         layer.cornerRadius = imageSize.cgFloat / 2
         clipsToBounds = true
-        image = UIImage(systemName: "person.fill")
+        image = UIImage(systemName: "person.fill")?.withTintColor(.white, renderingMode: .alwaysOriginal)
         contentMode = .scaleAspectFill
         backgroundColor = .systemGray2
     }

--- a/burstcamp/burstcamp/Presentation/Coordinator/App/AppCoordinator.swift
+++ b/burstcamp/burstcamp/Presentation/Coordinator/App/AppCoordinator.swift
@@ -74,7 +74,6 @@ final class AppCoordinator: AppCoordinatorProtocol {
     }
 
     func showTabBarFlow() {
-        UserManager.shared.addUserListener()
         let tabBarCoordinator = TabBarCoordinator(
             navigationController: navigationController,
             dependencyFactory: dependencyFactory

--- a/burstcamp/burstcamp/Presentation/Tab/MyPage/MyPage/View/MyPageProfileView.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/MyPage/MyPage/View/MyPageProfileView.swift
@@ -15,17 +15,28 @@ final class MyPageProfileView: UIView {
         imageSize: Constant.Image.profileMedium
     )
 
+    private lazy var profileInfoStackView = UIStackView(
+        views: [nicknameLabel],
+        spacing: Constant.space6
+    )
+
     private let nicknameLabel = UILabel().then {
         $0.textColor = .dynamicBlack
         $0.font = .extraBold16
     }
 
-    private let badgeView = DefaultBadgeView()
+    private let userBadgeView = DefaultBadgeView()
 
     private let blogTitleLabel = DefaultImageLabel(
         icon: UIImage(systemName: "book.fill"),
         text: "블로그를 등록해주세요."
     )
+
+    private let guestBadgeView = DefaultBadgeLabel(
+        textColor: Domain.guest.color
+    )
+
+    private var isConfigured = false
 
     // MARK: - Initializer
 
@@ -49,27 +60,50 @@ final class MyPageProfileView: UIView {
             make.centerY.equalToSuperview()
         }
 
-        let profileInfoStackView = profileInfoStackView(
-            views: [nicknameLabel, badgeView, blogTitleLabel])
         addSubview(profileInfoStackView)
+
         profileInfoStackView.snp.makeConstraints { make in
             make.leading.equalTo(profileImageView.snp.trailing).offset(Constant.space16)
             make.centerY.equalToSuperview()
         }
     }
 
-    private func profileInfoStackView(views: [UIView]) -> UIStackView {
-        return UIStackView(
-            views: views,
-            spacing: Constant.space6
-        )
+    // MARK: - 유저 프로필 사진 업데이트
+
+    private func updateUserProfileImage(user: User) {
+        guard user.domain != .guest else { return }
+        profileImageView.setImage(urlString: user.profileImageURL, isDiskCaching: true)
     }
 
+    // MARK: - 유저 Info 업데이트
+
+    private func configureProfileInfoView(domain: Domain) {
+        guard !isConfigured else { return }
+        if domain == .guest {
+            profileInfoStackView.addArrangedSubview(guestBadgeView)
+            profileInfoStackView.alignment = .leading
+        } else {
+            profileInfoStackView.addArrangedSubViews([userBadgeView, blogTitleLabel])
+        }
+
+        isConfigured = true
+    }
+
+    private func updateProfileInfoView(user: User) {
+        configureProfileInfoView(domain: user.domain)
+        if user.domain == .guest {
+            guestBadgeView.updateView(text: user.domain.representing)
+        } else {
+            userBadgeView.updateView(user: user)
+            blogTitleLabel.updateBlogImageLabel(user: user)
+        }
+    }
+}
+
+extension MyPageProfileView {
     func updateView(user: User) {
-        print("얼마나 마이페이지가 업데이트 되나?", #function)
-        profileImageView.setImage(urlString: user.profileImageURL, isDiskCaching: true)
+        updateUserProfileImage(user: user)
         nicknameLabel.text = user.nickname
-        badgeView.updateView(user: user)
-        blogTitleLabel.updateBlogImageLabel(user: user)
+        updateProfileInfoView(user: user)
     }
 }

--- a/burstcamp/burstcamp/Presentation/Tab/MyPage/MyPage/View/MyPageView.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/MyPage/MyPage/View/MyPageView.swift
@@ -18,8 +18,11 @@ final class MyPageView: UIView, ContainCollectionView {
 
     private let myInfoEditButton = DefaultButton(
         title: "내 정보 수정하기",
-        font: .bold14
-    )
+        font: .bold14,
+        backgroundColor: .systemGray5
+    ).then {
+        $0.isEnabled = false
+    }
 
     lazy var collectionView = UICollectionView(
         frame: .zero,
@@ -56,6 +59,8 @@ final class MyPageView: UIView, ContainCollectionView {
     lazy var myInfoEditButtonTapPublisher = myInfoEditButton.tapPublisher
     lazy var darkModeSwitchStatePublisher = darkModeSwitch.statePublisher
     lazy var notificationSwitchStatePublisher = notificationSwitch.statePublisher
+
+    private var isButtonUpdated: Bool = false
 
     // MARK: - Initializer
 
@@ -137,12 +142,22 @@ final class MyPageView: UIView, ContainCollectionView {
         }
     }
 
+    private func updateMyInfoEditButton(domain: Domain) {
+        guard domain != .guest && !isButtonUpdated else { return }
+        myInfoEditButton.isEnabled = true
+        myInfoEditButton.backgroundColor = .main
+        isButtonUpdated = true
+    }
+}
+
+extension MyPageView {
     func setCollectionViewDelegate(viewController: UICollectionViewDelegate) {
         collectionView.delegate = viewController
     }
 
     func updateView(user: User) {
         myPageProfileView.updateView(user: user)
+        updateMyInfoEditButton(domain: user.domain)
         notificationSwitch.setOn(user.isPushOn, animated: true)
     }
 

--- a/burstcamp/burstcamp/Presentation/Tab/MyPage/MyPage/View/MyPageView.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/MyPage/MyPage/View/MyPageView.swift
@@ -50,7 +50,7 @@ final class MyPageView: UIView, ContainCollectionView {
     }
 
     lazy var loadingLabel: UILabel = UILabel().then {
-        $0.text = "유저 정보 삭제 중"
+        $0.text = "탈퇴 중이에요"
         $0.font = .bold12
         $0.textColor = .dynamicBlack
         $0.isHidden = true

--- a/burstcamp/burstcamp/Presentation/Tab/MyPage/MyPage/ViewModel/MyPageViewModel.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/MyPage/MyPage/ViewModel/MyPageViewModel.swift
@@ -90,9 +90,19 @@ final class MyPageViewModel {
 }
 
 extension MyPageViewModel {
-    func deleteUserInfo(code: String) async throws {
+    func withdrawalWithGithub(code: String) async throws {
         do {
-            try await myPageUseCase.withdrawalWithGithub(code: code, userUUID: UserManager.shared.user.userUUID)
+            try await myPageUseCase.withdrawalWithGithub(code: code)
+        } catch {
+            print(error.localizedDescription)
+            withdrawalStop.send()
+            signOutFailMessage.send("탈퇴에 실패했어요.")
+        }
+    }
+
+    func withdrawalWithApple(idTokenString: String, nonce: String) async throws {
+        do {
+            try await myPageUseCase.withdrawalWithApple(idTokenString: idTokenString, nonce: nonce)
         } catch {
             print(error.localizedDescription)
             withdrawalStop.send()

--- a/burstcamp/burstcamp/Service/Firebase/Auth/BCFirebaseAuthService.swift
+++ b/burstcamp/burstcamp/Service/Firebase/Auth/BCFirebaseAuthService.swift
@@ -46,4 +46,18 @@ final class BCFirebaseAuthService: BCFirebaseAuthServiceProtocol {
         try await auth.currentUser?.delete()
         try auth.signOut()
     }
+
+    func loginWithApple(idTokenString: String, nonce: String) async throws -> String {
+        let credential = OAuthProvider.credential(withProviderID: "apple.com", idToken: idTokenString, rawNonce: nonce)
+
+        let result = try await auth.signIn(with: credential)
+        return result.user.uid
+    }
+
+    func withdrawalWithApple(idTokenString: String, nonce: String) async throws {
+        let credential = OAuthProvider.credential(withProviderID: "apple.com", idToken: idTokenString, rawNonce: nonce)
+        try await auth.currentUser?.reauthenticate(with: credential)
+        try await auth.currentUser?.delete()
+        try auth.signOut()
+    }
 }

--- a/burstcamp/burstcamp/Util/Error/Repository/UserRepository/UserRepositoryError.swift
+++ b/burstcamp/burstcamp/Util/Error/Repository/UserRepository/UserRepositoryError.swift
@@ -9,4 +9,5 @@ import Foundation
 
 enum UserRepositoryError: Error {
     case userNotExist
+    case createGuestID
 }

--- a/burstcamp/burstcamp/Util/Extension/Combine/UIControl+Combine.swift
+++ b/burstcamp/burstcamp/Util/Extension/Combine/UIControl+Combine.swift
@@ -5,6 +5,7 @@
 //  Created by neuli on 2022/11/21.
 //
 
+import AuthenticationServices
 import Combine
 import UIKit
 
@@ -98,6 +99,14 @@ extension UIRefreshControl {
         controlPublisher(for: .valueChanged)
             .compactMap { $0 as? UIRefreshControl }
             .filter { $0.isRefreshing == true }
+            .mapToVoid()
+            .eraseToAnyPublisher()
+    }
+}
+
+extension ASAuthorizationAppleIDButton {
+    var tapPublisher: AnyPublisher<Void, Never> {
+        controlPublisher(for: .touchUpInside)
             .mapToVoid()
             .eraseToAnyPublisher()
     }

--- a/burstcamp/burstcamp/Util/Extension/Type/String+sha256.swift
+++ b/burstcamp/burstcamp/Util/Extension/Type/String+sha256.swift
@@ -10,6 +10,40 @@ import Foundation
 
 extension String {
 
+    static func randomNonceString(length: Int = 32) -> String {
+      precondition(length > 0)
+      let charset: [Character] =
+        Array("0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._")
+      var result = ""
+      var remainingLength = length
+
+      while remainingLength > 0 {
+        let randoms: [UInt8] = (0 ..< 16).map { _ in
+          var random: UInt8 = 0
+          let errorCode = SecRandomCopyBytes(kSecRandomDefault, 1, &random)
+          if errorCode != errSecSuccess {
+            fatalError(
+              "Unable to generate nonce. SecRandomCopyBytes failed with OSStatus \(errorCode)"
+            )
+          }
+          return random
+        }
+
+        randoms.forEach { random in
+          if remainingLength == 0 {
+            return
+          }
+
+          if random < charset.count {
+            result.append(charset[Int(random)])
+            remainingLength -= 1
+          }
+        }
+      }
+
+      return result
+    }
+
     func sha256() -> String {
         let inputData = Data(self.utf8)
         let hashedData = SHA256.hash(data: inputData)

--- a/burstcamp/burstcamp/Util/Extension/Type/String+sha256.swift
+++ b/burstcamp/burstcamp/Util/Extension/Type/String+sha256.swift
@@ -1,0 +1,19 @@
+//
+//  String+toSHA.swift
+//  burstcamp
+//
+//  Created by youtak on 2023/01/30.
+//
+
+import CryptoKit
+import Foundation
+
+extension String {
+
+    func sha256() -> String {
+        let inputData = Data(self.utf8)
+        let hashedData = SHA256.hash(data: inputData)
+        let hashString = hashedData.compactMap { String(format: "%02x", $0) }.joined()
+        return hashString
+    }
+}

--- a/burstcamp/burstcamp/Util/Extension/UI/ViewController/UIViewController+.swift
+++ b/burstcamp/burstcamp/Util/Extension/UI/ViewController/UIViewController+.swift
@@ -46,7 +46,9 @@ extension UIViewController {
         toastMessageLabel.layer.cornerRadius = Constant.CornerRadius.radius8.cgFloat
         toastMessageLabel.clipsToBounds = true
 
-        self.view.addSubview(toastMessageLabel)
+        DispatchQueue.main.async {
+            self.view.addSubview(toastMessageLabel)
+        }
 
         // https://github.com/realm/SwiftLint/issues/3581
         // swiftlint:disable:next multiline_arguments

--- a/burstcamp/burstcamp/burstcamp.entitlements
+++ b/burstcamp/burstcamp/burstcamp.entitlements
@@ -4,5 +4,9 @@
 <dict>
 	<key>aps-environment</key>
 	<string>development</string>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
## 관련 이슈
<!--
이슈 번호 #000 작성  
ex) close #1 
--> 
- close #307 

## 내용
<!--
로직 설명  
필요시 스크린샷 첨부
--> 
- 애플 로그인을 추가했습니다. 로그인 시 게스트 모드로 로그인 됩니다.
  - Firebase에서 Apple 로그인 추가 설정
  - Apple Developer에서 추가 설정
  - XCode에서 설정
- 게스트 추가
  - Domain에 Guest를 추가했습니다. 애플 로그인이 완료되면 Guest 정보가 생성되고 바로 탭바로 이동합니다.
  - Guest 닉네임은 "Guest-\(userUUID앞 6자리)" 입니다.
  - 게스트인 경우 피드 보기, 스크랩, 알림 설정, 다크모드가 가능합니다.
  - 내 정보 수정하기가 불가능합니다.
  - Guest는 MyPage에서 View가 다르게 설정됩니다.
- AppleAuthViewController 클래스를 구현했습니다.
  - Apple Login이 필요한 LoginViewController와 MyPageViewController(탈퇴를 위한 재로그인)에서 상속을 받아 사용합니다.
- Auth Button을 만들었습니다.
  - 애플 로그인과 깃헙 로그인을 위한 버튼을 만들었습니다. 애플에서 제공하는 asAuthorizationAppleIDButton도 있지만 Github과의 통일성을 위해 커스텀이 필요했고, SFSymbol의 이미지를 사용해 구현했습니다. 

### 사진 및 영상

애플 버튼이 추가된 모습

|라이트 모드| 다크 모드|
|:---:|:---:|
|<img width = 300 src = "https://user-images.githubusercontent.com/71776532/215446119-d3cfb66a-b5f2-4b8c-ae3a-ad7012448983.PNG" />| <img width = 300 src = "https://user-images.githubusercontent.com/71776532/215446111-bbd9e232-dbe0-4276-b020-8d82f24c026e.PNG" />|

게스트 View

![스크린샷 2023-01-30 오후 6 59 08](https://user-images.githubusercontent.com/71776532/215445975-c04d10a9-cea2-4542-9c34-dc3b49d40885.png)



시연 영상

https://user-images.githubusercontent.com/71776532/215445854-4376e287-64ac-4581-b85c-393183e8482e.MP4


## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 
- LoginUseCase랑 LoginRepository가 많이 복잡해졌습니다. 분리와 리팩토링이 필요해보입니다.

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
- Firebase & Apple 로그인 : https://velog.io/@s_soo100/Flutter-Firebase%EB%A5%BC-%ED%99%9C%EC%9A%A9%ED%95%9C-%EC%95%A0%ED%94%8C-%EB%A1%9C%EA%B7%B8%EC%9D%B8-Apple-Sign-in-With-Firebase