### PR TITLE
[Feature] 추천피드 예외처리

### DIFF
--- a/burstcamp/burstcamp.xcodeproj/project.pbxproj
+++ b/burstcamp/burstcamp.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		141344D9292F803800187B86 /* UIControl+Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 141344D8292F803800187B86 /* UIControl+Combine.swift */; };
 		141344DB292F82BE00187B86 /* Feed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 141344DA292F82BE00187B86 /* Feed.swift */; };
 		14152B812988EAFE00FF5999 /* FeedRepositoryError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14152B802988EAFE00FF5999 /* FeedRepositoryError.swift */; };
+		14152B832988F3D000FF5999 /* FeedMockUpDatasource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14152B822988F3D000FF5999 /* FeedMockUpDatasource.swift */; };
 		1418960229377593005A42D4 /* UIScrollView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1418960129377593005A42D4 /* UIScrollView+.swift */; };
 		141A7A70297E5BDC003DD926 /* ScrapViewModelError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 141A7A6F297E5BDC003DD926 /* ScrapViewModelError.swift */; };
 		1422C62F292F08BC00337710 /* BCDateFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1422C62E292F08BC00337710 /* BCDateFormatter.swift */; };
@@ -305,6 +306,7 @@
 		141344D8292F803800187B86 /* UIControl+Combine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIControl+Combine.swift"; sourceTree = "<group>"; };
 		141344DA292F82BE00187B86 /* Feed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feed.swift; sourceTree = "<group>"; };
 		14152B802988EAFE00FF5999 /* FeedRepositoryError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedRepositoryError.swift; sourceTree = "<group>"; };
+		14152B822988F3D000FF5999 /* FeedMockUpDatasource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedMockUpDatasource.swift; sourceTree = "<group>"; };
 		1418960129377593005A42D4 /* UIScrollView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIScrollView+.swift"; sourceTree = "<group>"; };
 		141A7A6F297E5BDC003DD926 /* ScrapViewModelError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrapViewModelError.swift; sourceTree = "<group>"; };
 		1422C62E292F08BC00337710 /* BCDateFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BCDateFormatter.swift; sourceTree = "<group>"; };
@@ -1098,6 +1100,7 @@
 		149304902963EC3100B9BC71 /* Local */ = {
 			isa = PBXGroup;
 			children = (
+				14152B822988F3D000FF5999 /* FeedMockUpDatasource.swift */,
 				B5BC81BC2945BD500077BF29 /* FeedSingletonDataSource.swift */,
 				B5FF71452948EDB8008E69F2 /* FeedLocalDataSource.swift */,
 				B572F01F2948768100A9413C /* FeedRealmDataSource.swift */,
@@ -2120,6 +2123,7 @@
 				D89AE4E42933AEE900446AB3 /* ImageCacheError.swift in Sources */,
 				B50A27E929279F5D00DF3E1F /* NormalFeedCellFooter.swift in Sources */,
 				14755A472973FA3A0036B71D /* GithubLoginDatasource.swift in Sources */,
+				14152B832988F3D000FF5999 /* FeedMockUpDatasource.swift in Sources */,
 				143185F8292B5C88008CE459 /* ContainCollectionView.swift in Sources */,
 				B572EF832945E1CA00A9413C /* Publisher+Async.swift in Sources */,
 				B5DAD67B292E4C6800C4A126 /* FeedDetailViewController.swift in Sources */,

--- a/burstcamp/burstcamp.xcodeproj/project.pbxproj
+++ b/burstcamp/burstcamp.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		141344D7292F801100187B86 /* TimeInterval+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 141344D4292F801100187B86 /* TimeInterval+.swift */; };
 		141344D9292F803800187B86 /* UIControl+Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 141344D8292F803800187B86 /* UIControl+Combine.swift */; };
 		141344DB292F82BE00187B86 /* Feed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 141344DA292F82BE00187B86 /* Feed.swift */; };
+		14152B812988EAFE00FF5999 /* FeedRepositoryError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14152B802988EAFE00FF5999 /* FeedRepositoryError.swift */; };
 		1418960229377593005A42D4 /* UIScrollView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1418960129377593005A42D4 /* UIScrollView+.swift */; };
 		141A7A70297E5BDC003DD926 /* ScrapViewModelError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 141A7A6F297E5BDC003DD926 /* ScrapViewModelError.swift */; };
 		1422C62F292F08BC00337710 /* BCDateFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1422C62E292F08BC00337710 /* BCDateFormatter.swift */; };
@@ -303,6 +304,7 @@
 		141344D4292F801100187B86 /* TimeInterval+.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "TimeInterval+.swift"; sourceTree = "<group>"; };
 		141344D8292F803800187B86 /* UIControl+Combine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIControl+Combine.swift"; sourceTree = "<group>"; };
 		141344DA292F82BE00187B86 /* Feed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feed.swift; sourceTree = "<group>"; };
+		14152B802988EAFE00FF5999 /* FeedRepositoryError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedRepositoryError.swift; sourceTree = "<group>"; };
 		1418960129377593005A42D4 /* UIScrollView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIScrollView+.swift"; sourceTree = "<group>"; };
 		141A7A6F297E5BDC003DD926 /* ScrapViewModelError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrapViewModelError.swift; sourceTree = "<group>"; };
 		1422C62E292F08BC00337710 /* BCDateFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BCDateFormatter.swift; sourceTree = "<group>"; };
@@ -1371,6 +1373,7 @@
 			isa = PBXGroup;
 			children = (
 				14FF7A2C29838561001D6EDF /* MockUpFeedRepositoryError.swift */,
+				14152B802988EAFE00FF5999 /* FeedRepositoryError.swift */,
 			);
 			path = FeedRepository;
 			sourceTree = "<group>";
@@ -2085,6 +2088,7 @@
 				B572F01C2948688000A9413C /* Feed+RealmCompatible.swift in Sources */,
 				148A054F2972F62600664CCB /* SignUpUseCase.swift in Sources */,
 				3B7491E92938DCCD00A4BEA0 /* SignUpDomainViewModel.swift in Sources */,
+				14152B812988EAFE00FF5999 /* FeedRepositoryError.swift in Sources */,
 				141344D5292F801100187B86 /* TypeConversion.swift in Sources */,
 				141A7A70297E5BDC003DD926 /* ScrapViewModelError.swift in Sources */,
 				D89AE4E82933AF1E00446AB3 /* ImageCacheManager.swift in Sources */,

--- a/burstcamp/burstcamp/Data/Local/FeedMockUpDatasource.swift
+++ b/burstcamp/burstcamp/Data/Local/FeedMockUpDatasource.swift
@@ -1,0 +1,67 @@
+//
+//  FeedMockUpDatasource.swift
+//  burstcamp
+//
+//  Created by youtak on 2023/01/31.
+//
+
+import Foundation
+
+protocol FeedMockUpDataSource {
+    func createMockUpRecommendFeedList(count: Int) -> [Feed]
+}
+
+final class DefaultFeedMockUpDataSource: FeedMockUpDataSource {
+
+    func createMockUpRecommendFeedList(count: Int) -> [Feed] {
+        if count >= 3 {
+            return [createMockUpRecommendFeed1(), createMockUpRecommendFeed2(), createMockUpRecommendFeed3()]
+        } else if count == 2 {
+            return [createMockUpRecommendFeed1(), createMockUpRecommendFeed2()]
+        } else {
+            return [createMockUpRecommendFeed1()]
+        }
+    }
+
+    private func createMockUpRecommendFeed1() -> Feed {
+        return Feed(
+            feedUUID: UUID().uuidString,
+            writer: FeedWriter.getBurcam(domain: .web),
+            title: "버스트 캠프에 오신걸 환영해요 🥳",
+            pubDate: Date(),
+            url: "",
+            thumbnailURL: "",
+            content: "",
+            scrapCount: 0,
+            isScraped: false
+        )
+    }
+
+    private func createMockUpRecommendFeed2() -> Feed {
+        return Feed(
+            feedUUID: UUID().uuidString,
+            writer: FeedWriter.getBurcam(domain: .android),
+            title: "캠퍼들의 블로그를 둘러보며 함께 성장해요 🔥",
+            pubDate: Date(),
+            url: "",
+            thumbnailURL: "",
+            content: "",
+            scrapCount: 0,
+            isScraped: false
+        )
+    }
+
+    private func createMockUpRecommendFeed3() -> Feed {
+        return Feed(
+            feedUUID: UUID().uuidString,
+            writer: FeedWriter.getBurcam(domain: .iOS),
+            title: "Burstcamp! Burstcamp! Burstcamp!",
+            pubDate: Date(),
+            url: "",
+            thumbnailURL: "",
+            content: "",
+            scrapCount: 0,
+            isScraped: false
+        )
+    }
+}

--- a/burstcamp/burstcamp/Data/Repositories/FeedRepository/DefaultFeedRepository.swift
+++ b/burstcamp/burstcamp/Data/Repositories/FeedRepository/DefaultFeedRepository.swift
@@ -18,27 +18,61 @@ final class DefaultFeedRepository: FeedRepository {
     // MARK: - Home Feed 불러오기
     func fetchRecentHomeFeedList() async throws -> HomeFeedList {
         async let recommendFeed = bcFirestoreService.fetchRecommendFeed().map { Feed(feedAPIModel: $0) }
-        async let normalFeed = bcFirestoreService.fetchLatestNormalFeeds().map { Feed(feedAPIModel: $0) }
-        return HomeFeedList(
-            recommendFeed: try await recommendFeed,
-            normalFeed: try await normalFeed
-        )
+        do {
+            async let normalFeed = try bcFirestoreService.fetchLatestNormalFeeds().map { Feed(feedAPIModel: $0) }
+            return HomeFeedList(
+                recommendFeed: try await recommendFeed,
+                normalFeed: try await normalFeed
+            )
+        } catch {
+            // 추천피드는 값이 없으면 빈 배열이 넘어옴
+            // 홈에 피드가 없는 경우 error를 catch해 빈 배열을 내보냄
+            if let error = error as? FirestoreServiceError, error == .lastFetch {
+                return HomeFeedList(recommendFeed: try await recommendFeed, normalFeed: [])
+            } else {
+                throw FeedRepositoryError.fetchRecentHomeFeedList
+            }
+        }
     }
 
     func fetchMoreNormalFeed() async throws -> [Feed] {
-        return try await bcFirestoreService.fetchMoreNormalFeeds().map { Feed(feedAPIModel: $0)}
+        do {
+            return try await bcFirestoreService.fetchMoreNormalFeeds().map { Feed(feedAPIModel: $0)}
+        } catch {
+            if let error = error as? FirestoreServiceError, error == .lastFetch {
+                return []
+            } else {
+                throw FeedRepositoryError.fetchMoreNormalFeed
+            }
+        }
     }
 
     // MARK: - Scrap 피드 불러오기
     func fetchRecentScrapFeed(userUUID: String) async throws -> [Feed] {
-        return try await bcFirestoreService.fetchLatestScrapFeeds(userUUID: userUUID).map {
-            Feed(feedAPIModel: $0, isScraped: true)
+        do {
+            return try await bcFirestoreService.fetchLatestScrapFeeds(userUUID: userUUID).map {
+                Feed(feedAPIModel: $0, isScraped: true)
+            }
+        } catch {
+            if let error = error as? FirestoreServiceError, error == .scrapIsEmpty {
+                return []
+            } else {
+                throw FeedRepositoryError.fetchRecentScrapFeed
+            }
         }
     }
 
     func fetchMoreScrapFeed(userUUID: String) async throws -> [Feed] {
-        return try await bcFirestoreService.fetchMoreScrapFeeds(userUUID: userUUID).map {
-            Feed(feedAPIModel: $0, isScraped: true)
+        do {
+            return try await bcFirestoreService.fetchMoreScrapFeeds(userUUID: userUUID).map {
+                Feed(feedAPIModel: $0, isScraped: true)
+            }
+        } catch {
+            if let error = error as? FirestoreServiceError, error == .lastFetch {
+                return []
+            } else {
+                throw FeedRepositoryError.fetchMoreScrapFeed
+            }
         }
     }
 

--- a/burstcamp/burstcamp/Data/Repositories/FeedRepository/DefaultFeedRepository.swift
+++ b/burstcamp/burstcamp/Data/Repositories/FeedRepository/DefaultFeedRepository.swift
@@ -10,14 +10,17 @@ import Foundation
 final class DefaultFeedRepository: FeedRepository {
 
     private let bcFirestoreService: BCFirestoreService
+    private let feedMockUpDataSource: FeedMockUpDataSource
 
-    init(bcFirestoreService: BCFirestoreService) {
+    init(bcFirestoreService: BCFirestoreService, feedMockUpDataSource: FeedMockUpDataSource) {
         self.bcFirestoreService = bcFirestoreService
+        self.feedMockUpDataSource = feedMockUpDataSource
     }
 
     // MARK: - Home Feed 불러오기
     func fetchRecentHomeFeedList() async throws -> HomeFeedList {
         async let recommendFeed = bcFirestoreService.fetchRecommendFeed().map { Feed(feedAPIModel: $0) }
+
         do {
             async let normalFeed = try bcFirestoreService.fetchLatestNormalFeeds().map { Feed(feedAPIModel: $0) }
             return HomeFeedList(
@@ -87,5 +90,10 @@ final class DefaultFeedRepository: FeedRepository {
         let unScrapedFeed = feed.getUnScrapFeed()
         try await bcFirestoreService.unScrapFeed(FeedAPIModel(feed: unScrapedFeed), with: userUUID)
         return unScrapedFeed
+    }
+
+    // MARK: - 목업 추천 피드
+    func createMockUpRecommendFeedList(count: Int) -> [Feed] {
+        return feedMockUpDataSource.createMockUpRecommendFeedList(count: count)
     }
 }

--- a/burstcamp/burstcamp/Data/Repositories/FeedRepository/MockUpFeedRepository.swift
+++ b/burstcamp/burstcamp/Data/Repositories/FeedRepository/MockUpFeedRepository.swift
@@ -48,6 +48,10 @@ extension MockUpFeedRepository {
     func unScrapFeed(_ feed: Feed, userUUID: String) async throws -> Feed {
         throw MockUpFeedRepositoryError.noImplementation
     }
+
+    func createMockUpRecommendFeedList(count: Int) -> [Feed] {
+        return []
+    }
 }
 
 struct MockUpFeedData {

--- a/burstcamp/burstcamp/Domain/Interfaces/FeedRepository/FeedRepository.swift
+++ b/burstcamp/burstcamp/Domain/Interfaces/FeedRepository/FeedRepository.swift
@@ -16,4 +16,6 @@ protocol FeedRepository {
 
     func scrapFeed(_ feed: Feed, userUUID: String) async throws -> Feed
     func unScrapFeed(_ feed: Feed, userUUID: String) async throws -> Feed
+
+    func createMockUpRecommendFeedList(count: Int) -> [Feed]
 }

--- a/burstcamp/burstcamp/Domain/Model/Feed/FeedWriter.swift
+++ b/burstcamp/burstcamp/Domain/Model/Feed/FeedWriter.swift
@@ -59,9 +59,9 @@ extension FeedWriter {
             nickname: "버캠이",
             camperID: "",
             ordinalNumber: 7,
-            domain: .iOS,
+            domain: domain,
             profileImageURL: "",
-            blogTitle: "버스트캠프 운영진"
+            blogTitle: ""
         )
     }
 }

--- a/burstcamp/burstcamp/Domain/Model/Feed/FeedWriter.swift
+++ b/burstcamp/burstcamp/Domain/Model/Feed/FeedWriter.swift
@@ -52,4 +52,16 @@ extension FeedWriter {
         self.profileImageURL = ""
         self.blogTitle = ""
     }
+
+    static func getBurcam(domain: Domain) -> FeedWriter {
+        return FeedWriter(
+            userUUID: UUID().uuidString,
+            nickname: "버캠이",
+            camperID: "",
+            ordinalNumber: 7,
+            domain: .iOS,
+            profileImageURL: "",
+            blogTitle: "버스트캠프 운영진"
+        )
+    }
 }

--- a/burstcamp/burstcamp/Domain/UseCase/Auth/SignUp/DefaultSignUpUseCase.swift
+++ b/burstcamp/burstcamp/Domain/UseCase/Auth/SignUp/DefaultSignUpUseCase.swift
@@ -64,6 +64,7 @@ final class DefaultSignUpUseCase: SignUpUseCase {
         try await userRepository.saveUser(user)
         KeyChainManager.save(user: user)
         UserManager.shared.setUser(user)
+        UserManager.shared.addUserListener()
     }
 
     func saveFCMToken(_ token: String, to userUUID: String) async throws {

--- a/burstcamp/burstcamp/Domain/UseCase/Tab/Home/DefaultHomeUseCase.swift
+++ b/burstcamp/burstcamp/Domain/UseCase/Tab/Home/DefaultHomeUseCase.swift
@@ -23,8 +23,9 @@ final class DefaultHomeUseCase: HomeUseCase {
         let normalFeed = homeFeedList.normalFeed.map({ feed in
             return userScrapFeedUUIDs.contains(feed.feedUUID) ? feed.setIsScraped(true) : feed
         })
-        let recommendFeed = recommendFeedForCarousel(homeFeedList.recommendFeed)
-        return HomeFeedList(recommendFeed: recommendFeed, normalFeed: normalFeed)
+        let recommendFeed = addBurstcampNoticeIfNeed(recommendFeedList: homeFeedList.recommendFeed)
+        let tripleRecommendFeed = recommendFeedForCarousel(recommendFeed)
+        return HomeFeedList(recommendFeed: tripleRecommendFeed, normalFeed: normalFeed)
     }
 
     func fetchMoreNormalFeed() async throws -> [Feed] {
@@ -47,7 +48,16 @@ final class DefaultHomeUseCase: HomeUseCase {
         }
     }
 
-    // Carousel View를 위해 추천 피드를 2개 씩 복사해줘야 함
+    // MARK: RecommendFeed가 없는 경우 버스트 캠프 공지
+
+    private func addBurstcampNoticeIfNeed(recommendFeedList: [Feed]) -> [Feed] {
+        let targetCount = 3
+        let noticeFeed = feedRepository.createMockUpRecommendFeedList(count: 3 - recommendFeedList.count)
+        return recommendFeedList + noticeFeed
+    }
+
+    // MARK: - Carousel View를 위해 추천 피드를 2개씩 복사해줘야 함
+
     private func recommendFeedForCarousel(_ recommendFeedList: [Feed]) -> [Feed] {
         let newArrayOne = makeMockUpRecommendFeed(recommendFeedList)
         let newArrayTwo = makeMockUpRecommendFeed(recommendFeedList)

--- a/burstcamp/burstcamp/Presentation/Auth/LogIn/ViewModel/LogInViewModel.swift
+++ b/burstcamp/burstcamp/Presentation/Auth/LogIn/ViewModel/LogInViewModel.swift
@@ -46,10 +46,10 @@ final class LogInViewModel {
     func loginWithGithub(code: String) async throws {
         let (userNickname, userUUID) = try await loginUseCase.loginWithGithub(code: code)
         UserManager.shared.setUserUUID(userUUID)
-        UserManager.shared.addUserListener()
 
         let isUserExist = try await loginUseCase.checkIsExist(userUUID: userUUID)
         if isUserExist {
+            UserManager.shared.addUserListener()
             logInPublisher.send(.moveToTabBarScreen)
         } else {
             logInPublisher.send(.moveToDomainScreen(userNickname: userNickname))

--- a/burstcamp/burstcamp/Presentation/Common/View/RecommendCell/RecommendFeedCell.swift
+++ b/burstcamp/burstcamp/Presentation/Common/View/RecommendCell/RecommendFeedCell.swift
@@ -61,10 +61,22 @@ final class RecommendFeedCell: UICollectionViewCell {
             $0.leading.trailing.equalToSuperview().inset(20)
         }
     }
+
+    private func setUserInteractionEnabled(url: String) {
+        if url.isEmpty {
+            isUserInteractionEnabled = false
+        } else {
+            isUserInteractionEnabled = true
+        }
+    }
+
+    private func setUserImageToBurstcamper() {
+    }
 }
 
 extension RecommendFeedCell {
     func updateFeedCell(with feed: Feed) {
+        setUserInteractionEnabled(url: feed.url)
         titleLabel.text = feed.title
         userView.updateView(feedWriter: feed.writer)
         backgroundColor = feed.writer.domain.brightColor

--- a/burstcamp/burstcamp/Presentation/Common/View/RecommendCell/RecommendFeedUserView.swift
+++ b/burstcamp/burstcamp/Presentation/Common/View/RecommendCell/RecommendFeedUserView.swift
@@ -53,11 +53,19 @@ final class RecommendFeedUserView: UIStackView {
             $0.width.height.equalTo(Constant.Image.profileSmall)
         }
     }
+
+    private func updateProfileImage(profileImageURL: String) {
+        if profileImageURL.isEmpty {
+            profileImageView.image = .burstcamper
+        } else {
+            profileImageView.setImage(urlString: profileImageURL)
+        }
+    }
 }
 
 extension RecommendFeedUserView {
     func updateView(feedWriter: FeedWriter) {
-        profileImageView.setImage(urlString: feedWriter.profileImageURL)
+        updateProfileImage(profileImageURL: feedWriter.profileImageURL)
         nicknameLabel.text = feedWriter.nickname
         blogTitleLabel.text = feedWriter.blogTitle
     }

--- a/burstcamp/burstcamp/Presentation/Factory/DependencyFactory.swift
+++ b/burstcamp/burstcamp/Presentation/Factory/DependencyFactory.swift
@@ -22,6 +22,15 @@ final class DependencyFactory: DependencyFactoryProtocol {
     }
 
     // MARK: - Repository
+    private func createFeedRepository() -> FeedRepository {
+        let bcFirestoreService = BCFirestoreService()
+        let feedMockUpDatSource = DefaultFeedMockUpDataSource()
+        return DefaultFeedRepository(
+            bcFirestoreService: bcFirestoreService,
+            feedMockUpDataSource: feedMockUpDatSource
+        )
+    }
+
     private func createLoginRepository() -> LoginRepository {
         let bcFirebaseAuthService = BCFirebaseAuthService()
         let bcFirebaseFunctionService = BCFirebaseFunctionService()
@@ -96,26 +105,26 @@ extension DependencyFactory {
     }
 
     func createHomeViewModel() -> HomeViewModel {
-        let feedRepository = DefaultFeedRepository(bcFirestoreService: BCFirestoreService())
+        let feedRepository = createFeedRepository()
         let userRepository = createUserRepository()
         let homeUseCase = DefaultHomeUseCase(feedRepository: feedRepository, userRepository: userRepository)
         return HomeViewModel(homeUseCase: homeUseCase)
     }
 
     func createScrapPageViewModel() -> ScrapPageViewModel {
-        let feedRepository = DefaultFeedRepository(bcFirestoreService: BCFirestoreService())
+        let feedRepository = createFeedRepository()
         let scrapPageUseCase = DefaultScrapPageUseCase(feedRepository: feedRepository)
         return ScrapPageViewModel(scrapPageUseCase: scrapPageUseCase)
     }
 
     func createFeedDetailViewModel(feed: Feed) -> FeedDetailViewModel {
-        let feedRepository = DefaultFeedRepository(bcFirestoreService: BCFirestoreService())
+        let feedRepository = createFeedRepository()
         let feedDetailUseCase = DefaultFeedDetailUseCase(feedRepository: feedRepository)
         return FeedDetailViewModel(feedDetailUseCase: feedDetailUseCase, feed: feed)
     }
 
     func createFeedDetailViewModel(feedUUID: String) -> FeedDetailViewModel {
-        let feedRepository = DefaultFeedRepository(bcFirestoreService: BCFirestoreService())
+        let feedRepository = createFeedRepository()
         let feedDetailUseCase = DefaultFeedDetailUseCase(feedRepository: feedRepository)
         return FeedDetailViewModel(feedDetailUseCase: feedDetailUseCase, feedUUID: feedUUID)
     }

--- a/burstcamp/burstcamp/Presentation/Tab/Home/ViewModel/HomeViewModel.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/Home/ViewModel/HomeViewModel.swift
@@ -125,15 +125,15 @@ final class HomeViewModel {
                         debugPrint("normalFeed 페이지네이션 언래핑 에러")
                         return
                     }
+                    guard !normalFeed.isEmpty else {
+                        isLastFetch = true
+                        showToast.send("모든 피드를 불러왔어요")
+                        return
+                    }
                     self?.normalFeedData.append(contentsOf: normalFeed)
                     self?.moreFeed.send(normalFeed)
                 } catch {
-                    if let error = error as? FirestoreServiceError, error == .lastFetch {
-                        showToast.send("모든 피드를 불러왔어요")
-                        isLastFetch = true
-                    } else {
-                        showAlert.send(error)
-                    }
+                    showAlert.send(error)
                 }
                 isFetching = false
             }

--- a/burstcamp/burstcamp/Util/Error/Repository/FeedRepository/FeedRepositoryError.swift
+++ b/burstcamp/burstcamp/Util/Error/Repository/FeedRepository/FeedRepositoryError.swift
@@ -1,0 +1,15 @@
+//
+//  FeedRepositoryError.swift
+//  burstcamp
+//
+//  Created by youtak on 2023/01/31.
+//
+
+import Foundation
+
+enum FeedRepositoryError: Error {
+    case fetchRecentHomeFeedList
+    case fetchMoreNormalFeed
+    case fetchRecentScrapFeed
+    case fetchMoreScrapFeed
+}


### PR DESCRIPTION
## 관련 이슈
<!--
이슈 번호 #000 작성  
ex) close #1 
--> 
- close #309 
## 내용
<!--
로직 설명  
필요시 스크린샷 첨부
--> 
- 현재 가로 무한 스크롤을 위해서는 추천 피드가 최소 3개이상 필요함. 이를 위해 추천피드가 3개 이하 일 때 공지 피드 생성
- 추천 피드에 url이 없는 경우 userInteraction disable 해줌
- 추천 피드 유저가 프로필이미지가 없는 경우 버캠이로 대체
- 피드 요청 시 피드가 없어 발생하는 에러 -> FeedRepository에서 처리
  - 기존에 ViewModel에서 처리
  -  FeedRepository에서 에러를 catch해 피드가 없다면 빈 배열을 리턴해주는게 맞다고 생각함

### 결과 이미지 & 영상

|피드 1 개일 때| 피드 2 개일 때| 피드 3 개일 때|
|:---:|:---:|:---:|
|<img width = 250 src = "https://user-images.githubusercontent.com/71776532/215695593-4815f6f0-9f79-450c-b64a-453d6dd7002b.png" />| <img width = 250 src = "https://user-images.githubusercontent.com/71776532/215695687-e8772404-82e9-4252-991c-0d69e7c2bf58.gif" />|<img width = 250 src = "https://user-images.githubusercontent.com/71776532/215695705-a90af1c7-0f34-46d4-a1df-ce271410e092.gif" />|


## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 
- 제일 좋은 건 서버에 공지를 등록하는 거

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
