### PR TITLE
Feature/유저 업데이트날짜

### DIFF
--- a/burstcamp/burstcamp/Data/Repositories/UserRepository/DefaultUserRepository.swift
+++ b/burstcamp/burstcamp/Data/Repositories/UserRepository/DefaultUserRepository.swift
@@ -67,6 +67,7 @@ final class DefaultUserRepository: UserRepository {
             blogTitle: user.blogTitle,
             scrapFeedUUIDs: user.scrapFeedUUIDs,
             signupDate: user.signupDate,
+            updateDate: user.updateDate,
             isPushOn: user.isPushOn
         )
     }

--- a/burstcamp/burstcamp/Domain/Model/User/User.swift
+++ b/burstcamp/burstcamp/Domain/Model/User/User.swift
@@ -18,7 +18,7 @@ struct User: Codable, Equatable {
     let blogTitle: String
     private(set) var scrapFeedUUIDs: [String]
     let signupDate: Date
-    let updateDate: Date
+    private(set) var updateDate: Date
     let isPushOn: Bool
 
     mutating func setNickname(_ nickname: String) {

--- a/burstcamp/burstcamp/Domain/Model/User/User.swift
+++ b/burstcamp/burstcamp/Domain/Model/User/User.swift
@@ -18,6 +18,7 @@ struct User: Codable, Equatable {
     let blogTitle: String
     private(set) var scrapFeedUUIDs: [String]
     let signupDate: Date
+    let updateDate: Date
     let isPushOn: Bool
 
     mutating func setNickname(_ nickname: String) {
@@ -46,8 +47,11 @@ extension User {
         self.blogTitle = dictionary["blogTitle"] as? String ?? ""
         self.scrapFeedUUIDs = dictionary["scrapFeedUUIDs"] as? [String] ?? []
         self.signupDate = dictionary["signupDate"] as? Date ?? Date()
+        self.updateDate = dictionary["updateDate"] as? Date ?? Date(timeIntervalSince1970: 0)
         self.isPushOn = dictionary["isPushOn"] as? Bool ?? false
     }
+
+    // MARK: - 회원가입을 위한 유저 이니셜라이져
 
     init?(userUUID: String, signUpUser: SignUpUser, blogTitle: String) {
         self.userUUID = userUUID
@@ -68,8 +72,11 @@ extension User {
         self.blogTitle = blogTitle
         self.scrapFeedUUIDs = []
         self.signupDate = Date()
+        self.updateDate = Date()
         self.isPushOn = false
     }
+
+    // MARK: - UserAPIModel -> User
 
     init(userAPIModel: UserAPIModel) {
         self.userUUID = userAPIModel.userUUID
@@ -82,6 +89,7 @@ extension User {
         self.blogTitle = userAPIModel.blogTitle
         self.scrapFeedUUIDs = userAPIModel.scrapFeedUUIDs
         self.signupDate = userAPIModel.signupDate
+        self.updateDate = userAPIModel.updateDate
         self.isPushOn = userAPIModel.isPushOn
     }
 
@@ -89,6 +97,7 @@ extension User {
     /// - Parameters:
     ///   - userUUID: 로그인을 통해 얻은 userUUID
     ///   - nickname: 게스트 닉네임
+    ///
     init (userUUID: String, nickname: String) {
         self.userUUID = userUUID
         self.nickname = nickname
@@ -100,6 +109,7 @@ extension User {
         self.blogTitle = ""
         self.scrapFeedUUIDs = []
         self.signupDate = Date()
+        self.updateDate = Date(timeIntervalSince1970: 0)
         self.isPushOn = false
     }
 

--- a/burstcamp/burstcamp/Domain/Model/User/User.swift
+++ b/burstcamp/burstcamp/Domain/Model/User/User.swift
@@ -32,6 +32,10 @@ struct User: Codable, Equatable {
     mutating func setBlogURL(_ blogURL: String) {
         self.blogURL = blogURL
     }
+
+    mutating func setUpdateDate() {
+        self.updateDate = Date()
+    }
 }
 
 extension User {

--- a/burstcamp/burstcamp/Domain/Model/User/User.swift
+++ b/burstcamp/burstcamp/Domain/Model/User/User.swift
@@ -72,7 +72,7 @@ extension User {
         self.blogTitle = blogTitle
         self.scrapFeedUUIDs = []
         self.signupDate = Date()
-        self.updateDate = Date()
+        self.updateDate = Date(timeIntervalSince1970: 0)
         self.isPushOn = false
     }
 

--- a/burstcamp/burstcamp/Domain/UseCase/Auth/SignUp/DefaultSignUpUseCase.swift
+++ b/burstcamp/burstcamp/Domain/UseCase/Auth/SignUp/DefaultSignUpUseCase.swift
@@ -65,7 +65,7 @@ final class DefaultSignUpUseCase: SignUpUseCase {
         KeyChainManager.save(user: user)
         UserManager.shared.setUser(user)
     }
-    
+
     func saveFCMToken(_ token: String, to userUUID: String) async throws {
         try await userRepository.saveFCMToken(token, to: userUUID)
     }

--- a/burstcamp/burstcamp/Domain/UseCase/Auth/SignUp/DefaultSignUpUseCase.swift
+++ b/burstcamp/burstcamp/Domain/UseCase/Auth/SignUp/DefaultSignUpUseCase.swift
@@ -64,9 +64,8 @@ final class DefaultSignUpUseCase: SignUpUseCase {
         try await userRepository.saveUser(user)
         KeyChainManager.save(user: user)
         UserManager.shared.setUser(user)
-        UserManager.shared.addUserListener()
     }
-
+    
     func saveFCMToken(_ token: String, to userUUID: String) async throws {
         try await userRepository.saveFCMToken(token, to: userUUID)
     }

--- a/burstcamp/burstcamp/Domain/UseCase/Tab/MyPage/DefaultMyPageUseCase.swift
+++ b/burstcamp/burstcamp/Domain/UseCase/Tab/MyPage/DefaultMyPageUseCase.swift
@@ -38,6 +38,20 @@ final class DefaultMyPageUseCase: MyPageUseCase {
         if !isSuccess { throw MyPageUseCaseError.withdrawal }
     }
 
+    // MARK: - 마이페이지 수정
+
+    func canUpdateMyInfo() -> Bool {
+        let updateDate = UserManager.shared.user.updateDate
+        return updateDate.isPassed30Days()
+    }
+
+    func getNextUpdateDate() -> Date {
+        let updateDate = UserManager.shared.user.updateDate
+        return updateDate.after30Days()
+    }
+
+    // MARK: - 설정
+
     func updateUserPushState(userUUID: String, isPushOn: Bool) async throws {
         try await userRepository.updateUserPushState(userUUID: userUUID, isPushOn: isPushOn)
     }

--- a/burstcamp/burstcamp/Domain/UseCase/Tab/MyPage/MyPageEdit/DefaultMyPageEditUseCase.swift
+++ b/burstcamp/burstcamp/Domain/UseCase/Tab/MyPage/MyPageEdit/DefaultMyPageEditUseCase.swift
@@ -52,6 +52,7 @@ final class DefaultMyPageEditUseCase: MyPageEditUseCase {
     }
 
     func updateUser() async throws {
+        editedUser.setUpdateDate()
         try await updateFirestorageImage(imageData)
         try await userRepository.updateUser(editedUser)
     }

--- a/burstcamp/burstcamp/Domain/UseCase/Tab/MyPage/MyPageUseCase.swift
+++ b/burstcamp/burstcamp/Domain/UseCase/Tab/MyPage/MyPageUseCase.swift
@@ -11,6 +11,9 @@ protocol MyPageUseCase {
     func withdrawalWithGithub(code: String) async throws
     func withdrawalWithApple(idTokenString: String, nonce: String) async throws
 
+    func canUpdateMyInfo() -> Bool
+    func getNextUpdateDate() -> Date
+
     func updateUserPushState(userUUID: String, isPushOn: Bool) async throws
     func updateUserDarkModeState(appearance: Appearance)
     func updateLocalUser(_ user: User)

--- a/burstcamp/burstcamp/Presentation/Auth/LogIn/ViewModel/LogInViewModel.swift
+++ b/burstcamp/burstcamp/Presentation/Auth/LogIn/ViewModel/LogInViewModel.swift
@@ -49,7 +49,6 @@ final class LogInViewModel {
 
         let isUserExist = try await loginUseCase.checkIsExist(userUUID: userUUID)
         if isUserExist {
-            UserManager.shared.addUserListener()
             logInPublisher.send(.moveToTabBarScreen)
         } else {
             logInPublisher.send(.moveToDomainScreen(userNickname: userNickname))
@@ -64,7 +63,6 @@ final class LogInViewModel {
         if !isUserExist {
             try await loginUseCase.createGuest(userUUID: userUUID)
         }
-        UserManager.shared.addUserListener()
         logInPublisher.send(.moveToTabBarScreen)
     }
 }

--- a/burstcamp/burstcamp/Presentation/Coordinator/App/AppCoordinator.swift
+++ b/burstcamp/burstcamp/Presentation/Coordinator/App/AppCoordinator.swift
@@ -74,6 +74,8 @@ final class AppCoordinator: AppCoordinatorProtocol {
     }
 
     func showTabBarFlow() {
+        UserManager.shared.addUserListener()
+
         let tabBarCoordinator = TabBarCoordinator(
             navigationController: navigationController,
             dependencyFactory: dependencyFactory

--- a/burstcamp/burstcamp/Presentation/Tab/MyPage/Edit/View/MyPageEditView.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/MyPage/Edit/View/MyPageEditView.swift
@@ -78,6 +78,12 @@ final class MyPageEditView: UIView {
 
     private let finishEditButton = DefaultButton(title: "수정완료")
 
+    private let descriptionLabel = UILabel().then {
+        $0.text = "유저 정보는 30일에 1회 수정이 가능해요"
+        $0.textColor = .systemGray2
+        $0.font = .regular12
+    }
+
     lazy var cameraButtonTapPublisher = cameraButton.tapPublisher
     lazy var nickNameTextFieldTextPublisher = nickNameTextField.textPublisher
     lazy var blogLinkTextFieldTextPublisher = blogLinkTextField.textPublisher
@@ -128,6 +134,12 @@ final class MyPageEditView: UIView {
         addSubview(editStackView)
         editStackView.snp.makeConstraints { make in
             make.top.equalTo(profileImageView.snp.bottom).offset(Constant.space48)
+            make.horizontalEdges.equalToSuperview().inset(Constant.space16)
+        }
+
+        addSubview(descriptionLabel)
+        descriptionLabel.snp.makeConstraints { make in
+            make.top.equalTo(editStackView.snp.bottom).offset(Constant.space12)
             make.horizontalEdges.equalToSuperview().inset(Constant.space16)
         }
     }

--- a/burstcamp/burstcamp/Presentation/Tab/MyPage/MyPage/ViewController/MyPageViewController.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/MyPage/MyPage/ViewController/MyPageViewController.swift
@@ -69,6 +69,7 @@ final class MyPageViewController: AppleAuthViewController {
 
     private func bind() {
         let input = MyPageViewModel.Input(
+            myInfoEditButtonTap: myPageView.myInfoEditButtonTapPublisher,
             notificationDidSwitch: myPageView.notificationSwitchStatePublisher,
             darkModeDidSwitch: myPageView.darkModeSwitchStatePublisher,
             withdrawDidTap: withdrawalButtonPublisher
@@ -120,15 +121,17 @@ final class MyPageViewController: AppleAuthViewController {
             }
             .store(in: &cancelBag)
 
+        output.myInfoEditButtonTap
+            .sink { [weak self] canEdit in
+                self?.editMyInfoEdit(canEdit: canEdit)
+            }
+            .store(in: &cancelBag)
+
         myPageView.notificationSwitchStatePublisher
             .sink { isOn in
                 let text = isOn ? "알림이 켜졌어요." : "알림이 꺼졌어요."
                 self.showToastMessage(text: text, icon: UIImage(systemName: "bell.fill"))
             }
-            .store(in: &cancelBag)
-
-        myPageView.myInfoEditButtonTapPublisher
-            .sink { _ in self.moveToMyPageEditScreen() }
             .store(in: &cancelBag)
 
         toastMessagePublisher
@@ -185,6 +188,15 @@ final class MyPageViewController: AppleAuthViewController {
             self.myPageView.indicatorView.stopAnimating()
             self.myPageView.loadingLabel.isHidden = true
             self.setUserInteraction(isEnabled: true)
+        }
+    }
+
+    private func editMyInfoEdit(canEdit: Bool) {
+        if canEdit {
+            moveToMyPageEditScreen()
+        } else {
+            let nextUpdateDate = viewModel.getNextUpdateDate().yearMonthDateFormatString
+            showAlert(message: "한 달에 1회 수정 가능해요. 다음 수정 가능 날짜는 \(nextUpdateDate) 이에요.")
         }
     }
 

--- a/burstcamp/burstcamp/Presentation/Tab/MyPage/MyPage/ViewModel/MyPageViewModel.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/MyPage/MyPage/ViewModel/MyPageViewModel.swift
@@ -22,6 +22,7 @@ final class MyPageViewModel {
     }
 
     struct Input {
+        let myInfoEditButtonTap: AnyPublisher<Void, Never>
         let notificationDidSwitch: AnyPublisher<Bool, Never>
         let darkModeDidSwitch: AnyPublisher<Bool, Never>
         let withdrawDidTap: PassthroughSubject<Void, Never>
@@ -36,6 +37,7 @@ final class MyPageViewModel {
         var signOutFailMessage = PassthroughSubject<String, Never>()
         var withdrawalStop = PassthroughSubject<Void, Never>()
         var loginProviderPublisher: AnyPublisher<LoginProvider, Never>
+        let myInfoEditButtonTap: AnyPublisher<Bool, Never>
     }
 
     private var cancelBag = Set<AnyCancellable>()
@@ -63,11 +65,18 @@ final class MyPageViewModel {
             }
             .store(in: &cancelBag)
 
+        let myInfoEditButtonTap = input.myInfoEditButtonTap
+            .map { _ in
+                self.canUpdateMyInfo()
+            }
+            .eraseToAnyPublisher()
+
         let output = Output(
             updateUserValue: updateUserValue,
             signOutFailMessage: signOutFailMessage,
             withdrawalStop: withdrawalStop,
-            loginProviderPublisher: loginProviderPublisher.eraseToAnyPublisher()
+            loginProviderPublisher: loginProviderPublisher.eraseToAnyPublisher(),
+            myInfoEditButtonTap: myInfoEditButtonTap
         )
 
         UserManager.shared.userUpdatePublisher
@@ -86,6 +95,10 @@ final class MyPageViewModel {
         } else {
             loginProviderPublisher.send(.github)
         }
+    }
+
+    private func canUpdateMyInfo() -> Bool {
+        return myPageUseCase.canUpdateMyInfo()
     }
 }
 
@@ -108,5 +121,9 @@ extension MyPageViewModel {
             withdrawalStop.send()
             signOutFailMessage.send("탈퇴에 실패했어요.")
         }
+    }
+
+    func getNextUpdateDate() -> Date {
+        return myPageUseCase.getNextUpdateDate()
     }
 }

--- a/burstcamp/burstcamp/Service/Firebase/Model/UserAPIModel.swift
+++ b/burstcamp/burstcamp/Service/Firebase/Model/UserAPIModel.swift
@@ -20,6 +20,7 @@ struct UserAPIModel {
     let blogTitle: String
     var scrapFeedUUIDs: [String]
     let signupDate: Date
+    let updateDate: Date
     let isPushOn: Bool
 }
 
@@ -33,9 +34,11 @@ extension UserAPIModel {
         self.ordinalNumber = data["ordinalNumber"] as? Int ?? 7
         self.blogURL = data["blogURL"] as? String ?? ""
         self.blogTitle = data["blogTitle"] as? String ?? ""
-        let timeStampDate = data["signupDate"] as? Timestamp ?? Timestamp()
         self.scrapFeedUUIDs = data["scrapFeedUUIDs"] as? [String] ?? []
-        self.signupDate = timeStampDate.dateValue()
+        let timestampSignupDate = data["signupDate"] as? Timestamp ?? Timestamp()
+        self.signupDate = timestampSignupDate.dateValue()
+        let timestampUpdateDate = data["updateDate"] as? Timestamp ?? Timestamp(date: Date(timeIntervalSince1970: 0))
+        self.updateDate = timestampUpdateDate.dateValue()
         self.isPushOn = data["isPushOn"] as? Bool ?? false
     }
 
@@ -51,6 +54,7 @@ extension UserAPIModel {
             "blogTitle": blogTitle,
             "scrapFeedUUUIDs": scrapFeedUUIDs,
             "signupDate": Timestamp(date: signupDate),
+            "updateDate": Timestamp(date: updateDate),
             "isPushOn": isPushOn
         ]
     }

--- a/burstcamp/burstcamp/Service/Firebase/Model/UserAPIModel.swift
+++ b/burstcamp/burstcamp/Service/Firebase/Model/UserAPIModel.swift
@@ -52,7 +52,7 @@ extension UserAPIModel {
             "ordinalNumber": ordinalNumber,
             "blogURL": blogURL,
             "blogTitle": blogTitle,
-            "scrapFeedUUUIDs": scrapFeedUUIDs,
+            "scrapFeedUUIDs": scrapFeedUUIDs,
             "signupDate": Timestamp(date: signupDate),
             "updateDate": Timestamp(date: updateDate),
             "isPushOn": isPushOn

--- a/burstcamp/burstcamp/Util/Extension/Type/Date+FormatString.swift
+++ b/burstcamp/burstcamp/Util/Extension/Type/Date+FormatString.swift
@@ -22,4 +22,31 @@ extension Date {
 
         return formatter.string(from: self)
     }
+
+    /// 30일 지났는지 확인해주는 함수
+    /// - Returns: Bool 값
+    /// @discussion
+    /// - 1월 1일 -> 1월 31일 true
+    /// - 1월 2일 -> 1월 31일 false, 2월 1일 true
+    // swiftlint: disable force_unwrapping
+    func isPassed30Days() -> Bool {
+        // 날짜에 맞추기 위해 뒤에 시간을 잘라줘야됨 2023-01-01-23:00:00 -> 2023-01-01
+        // 시간이 남아있으면 1월 1일 오후 11시에 업데이트를 하면 1월 30일 오후 11시부터 업데이트가 가능함
+        // formatter를 통해 시간을 짤라 날짜로만 계산함
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        let stringDate = formatter.string(from: self)
+        let targetDate = formatter.date(from: stringDate)!
+
+        let after30Days = Calendar.current.date(byAdding: .day, value: 30, to: targetDate)!
+        let now = Date()
+
+        print(targetDate, after30Days, now)
+        // after30Days < now
+        return after30Days.compare(now) == .orderedAscending ? true : false
+    }
+
+    func after30Days() -> Date {
+        return Calendar.current.date(byAdding: .day, value: +30, to: self)!
+    }
 }

--- a/burstcamp/burstcamp/Util/Extension/Type/Date+FormatString.swift
+++ b/burstcamp/burstcamp/Util/Extension/Type/Date+FormatString.swift
@@ -23,11 +23,13 @@ extension Date {
         return formatter.string(from: self)
     }
 
+    // swiftlint: disable orphaned_doc_comment
     /// 30일 지났는지 확인해주는 함수
     /// - Returns: Bool 값
     /// @discussion
     /// - 1월 1일 -> 1월 31일 true
     /// - 1월 2일 -> 1월 31일 false, 2월 1일 true
+
     // swiftlint: disable force_unwrapping
     func isPassed30Days() -> Bool {
         // 날짜에 맞추기 위해 뒤에 시간을 잘라줘야됨 2023-01-01-23:00:00 -> 2023-01-01
@@ -41,7 +43,6 @@ extension Date {
         let after30Days = Calendar.current.date(byAdding: .day, value: 30, to: targetDate)!
         let now = Date()
 
-        print(targetDate, after30Days, now)
         // after30Days < now
         return after30Days.compare(now) == .orderedAscending ? true : false
     }


### PR DESCRIPTION
## 관련 이슈
<!--
이슈 번호 #000 작성  
ex) close #1 
--> 
- close #275  
## 내용
<!--
로직 설명  
필요시 스크린샷 첨부
--> 
- 유저 정보 수정 횟수를 한 달에 1회로 제한했습니다.
- 유저 Model에 updateDate를 추가했습니다.
  - 가입시 1970년 1월 1일로 설정됩니다. -> 최초 1회 수정 가능
  - 30일을 기준으로 했습니다.
    - 1월 1일 -> 1월 31일 true
    - 1월 2일 -> 1월 31일 false, 2월 1일 true 
    -  날짜에 맞추기 위해 뒤에 시간을 잘라줬습니다. 2023-01-01-23:00:00 -> 2023-01-01  
        시간이 남아있으면 1월 1일 오후 11시에 업데이트를 하면 1월 30일 오후 11시부터 업데이트가 가능합니다.
        formatter를 통해 시간을 짤라 날짜로만 계산합니다.  
        이를 통해 1월 1일에 업데이트를 했으면 1월 31일에 업데이트가 가능합니다.
- Date extension에 30일이 지났는지 확인하는 함수를 구현했습니다.
- 유저가 업데이트시 updateDate도 갱신됩니다.
- MyPageEditView에 안내 문구를 추가했습니다.
- 30일이 안 지났으면 Alert으로 다음 수정날짜를 알려줍니다.

### 결과

|MyPageEdit View에 안내 |업데이트 불가 안내 Alert|
|:---:|:---:|
|<img width = 250 src = "https://user-images.githubusercontent.com/71776532/215786532-ea156cb9-7c55-4557-816b-90f876d72759.png" />|<img width = 250 src = "https://user-images.githubusercontent.com/71776532/215786548-b3c8a7ff-66e6-48c3-8a0c-06c524d3578e.png" />|

## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
