### PR TITLE
[Fix] 추천피드 에러

### DIFF
--- a/burstcamp/burstcamp/Data/Local/FeedMockUpDatasource.swift
+++ b/burstcamp/burstcamp/Data/Local/FeedMockUpDatasource.swift
@@ -18,8 +18,10 @@ final class DefaultFeedMockUpDataSource: FeedMockUpDataSource {
             return [createMockUpRecommendFeed1(), createMockUpRecommendFeed2(), createMockUpRecommendFeed3()]
         } else if count == 2 {
             return [createMockUpRecommendFeed1(), createMockUpRecommendFeed2()]
-        } else {
+        } else if count == 1 {
             return [createMockUpRecommendFeed1()]
+        } else {
+            return []
         }
     }
 

--- a/burstcamp/burstcamp/Domain/UseCase/Tab/Home/DefaultHomeUseCase.swift
+++ b/burstcamp/burstcamp/Domain/UseCase/Tab/Home/DefaultHomeUseCase.swift
@@ -52,7 +52,7 @@ final class DefaultHomeUseCase: HomeUseCase {
 
     private func addBurstcampNoticeIfNeed(recommendFeedList: [Feed]) -> [Feed] {
         let targetCount = 3
-        let noticeFeed = feedRepository.createMockUpRecommendFeedList(count: 3 - recommendFeedList.count)
+        let noticeFeed = feedRepository.createMockUpRecommendFeedList(count: targetCount - recommendFeedList.count)
         return recommendFeedList + noticeFeed
     }
 

--- a/burstcamp/burstcamp/Domain/UseCase/Tab/Home/DefaultHomeUseCase.swift
+++ b/burstcamp/burstcamp/Domain/UseCase/Tab/Home/DefaultHomeUseCase.swift
@@ -51,7 +51,7 @@ final class DefaultHomeUseCase: HomeUseCase {
     // MARK: RecommendFeed가 없는 경우 버스트 캠프 공지
 
     private func addBurstcampNoticeIfNeed(recommendFeedList: [Feed]) -> [Feed] {
-        let targetCount = 3
+        let targetCount = 4
         let noticeFeed = feedRepository.createMockUpRecommendFeedList(count: targetCount - recommendFeedList.count)
         return recommendFeedList + noticeFeed
     }

--- a/burstcamp/burstcamp/Presentation/Tab/Home/View/HomeView.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/Home/View/HomeView.swift
@@ -11,7 +11,7 @@ import SnapKit
 
 final class HomeView: UIView, ContainCollectionView {
 
-    private let recommendFeedCount = 3
+    private var recommendFeedCount = 3
 
     lazy var collectionView = UICollectionView(
         frame: .zero,
@@ -130,6 +130,7 @@ final class HomeView: UIView, ContainCollectionView {
         let leftLimitOffsetX = startOffsetX + contentSize
         let rightLimitOffsetX = startOffsetX + contentSize * (2 * contentCount + 1).cgFloat
         let currentOffsetX = offset.x
+        print(recommendFeedCount, leftLimitOffsetX, rightLimitOffsetX, currentOffsetX)
         if currentOffsetX <= leftLimitOffsetX || currentOffsetX >= rightLimitOffsetX {
             scrollToCenter()
         }
@@ -137,8 +138,9 @@ final class HomeView: UIView, ContainCollectionView {
 
     private func scrollToCenter() {
         DispatchQueue.main.async { [weak self] in
-            self?.collectionView.scrollToItem(
-                at: IndexPath(row: Constant.recommendFeed + 1, section: 0),
+            guard let self = self else { return }
+            self.collectionView.scrollToItem(
+                at: IndexPath(row: self.recommendFeedCount + 1, section: 0),
                 at: .centeredHorizontally,
                 animated: false
             )
@@ -218,5 +220,11 @@ final class HomeView: UIView, ContainCollectionView {
         case .normal:
             return []
         }
+    }
+}
+
+extension HomeView {
+    func setRecommendFeedCount(_ count: Int) {
+        recommendFeedCount = count
     }
 }

--- a/burstcamp/burstcamp/Presentation/Tab/Home/ViewController/HomeViewController.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/Home/ViewController/HomeViewController.swift
@@ -104,8 +104,7 @@ extension HomeViewController {
         output.recentFeed
             .receive(on: DispatchQueue.main)
             .sink { [weak self] homeFeedList in
-                self?.homeView.hideSkeleton()
-                self?.reloadHomeFeedList(homeFeedList: homeFeedList)
+                self?.receiveHomeFeedList(homeFeedList: homeFeedList)
             }
             .store(in: &cancelBag)
 
@@ -163,6 +162,15 @@ extension HomeViewController {
                 }
             }
             .store(in: &cell.cancelBag)
+    }
+
+    // MARK: - bind 내부 함수들 추출
+
+    private func receiveHomeFeedList(homeFeedList: HomeFeedList) {
+        homeView.hideSkeleton()
+        // carousel View를 위한 설정 -> 2개씩 복사 해줬으므로 진짜 개수는 3으로 나눠줘야 함
+        homeView.setRecommendFeedCount(homeFeedList.recommendFeed.count / 3)
+        reloadHomeFeedList(homeFeedList: homeFeedList)
     }
 }
 


### PR DESCRIPTION
## 관련 이슈
<!--
이슈 번호 #000 작성  
ex) close #1 
--> 
- close #315 

## 내용
<!--
로직 설명  
필요시 스크린샷 첨부
--> 
- 기본적으로 목업 피드 1개 유지 -> 공지용
- else 문 처리를 잘못해 목업피드가 추가로 생기는 에러 수정
- 기존에 추천 피드 3개를 기준으로 스크롤 뷰 로직을 설계해둠 -> 3개 이상일 때 대응할 수 있도록 수정
  - 서버에 추천피드가 없더라도 프론트에서 최소 3개의 목업 피드를 만들기때문에 무한 스크롤 대응 가능 

## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
