### PR TITLE
[Feature] UIViewController extension에 indicator view 설정

### DIFF
--- a/burstcamp/burstcamp/Presentation/Auth/LogIn/View/LogInView.swift
+++ b/burstcamp/burstcamp/Presentation/Auth/LogIn/View/LogInView.swift
@@ -41,17 +41,6 @@ final class LogInView: UIView {
         $0.textColor = .systemGray2
     }
 
-    lazy var activityIndicator: UIActivityIndicatorView = UIActivityIndicatorView().then {
-        $0.style = .medium
-    }
-
-    lazy var loadingLabel: UILabel = UILabel().then {
-        $0.text = "캠퍼 인증 중"
-        $0.font = .bold12
-        $0.textColor = .dynamicBlack
-        $0.isHidden = true
-    }
-
     override init(frame: CGRect) {
         super.init(frame: frame)
         configureUI()
@@ -75,8 +64,6 @@ final class LogInView: UIView {
         addSubview(appleAuthButton)
         addSubview(camperAuthButton)
         addSubview(camperAuthLabel)
-        addSubview(activityIndicator)
-        addSubview(loadingLabel)
     }
 
     private func configureLayout() {
@@ -111,15 +98,6 @@ final class LogInView: UIView {
         camperAuthLabel.snp.makeConstraints {
             $0.top.equalTo(camperAuthButton.snp.bottom).offset(Constant.space12)
             $0.centerX.equalToSuperview()
-        }
-
-        activityIndicator.snp.makeConstraints {
-            $0.centerX.centerY.equalToSuperview()
-        }
-
-        loadingLabel.snp.makeConstraints {
-            $0.centerX.equalToSuperview()
-            $0.top.equalTo(activityIndicator.snp.bottom).offset(Constant.space10)
         }
     }
 }

--- a/burstcamp/burstcamp/Presentation/Auth/SignUp/Blog/SignUpBlogView.swift
+++ b/burstcamp/burstcamp/Presentation/Auth/SignUp/Blog/SignUpBlogView.swift
@@ -59,16 +59,6 @@ final class SignUpBlogView: UIView {
         $0.alpha = 0.3
     }
 
-    lazy var activityIndicator: UIActivityIndicatorView = UIActivityIndicatorView().then {
-        $0.style = .medium
-    }
-
-    lazy var indicatorLabel: UILabel = UILabel().then {
-        $0.text = "가입 중"
-        $0.font = .bold12
-        $0.isHidden = true
-    }
-
     override init(frame: CGRect) {
         super.init(frame: frame)
         configureUI()
@@ -89,8 +79,6 @@ final class SignUpBlogView: UIView {
         addSubview(subLabel)
         addSubview(blogTextField)
         addSubview(skipButton)
-        addSubview(activityIndicator)
-        addSubview(indicatorLabel)
     }
 
     private func configureLayout() {
@@ -121,15 +109,6 @@ final class SignUpBlogView: UIView {
 
         nextButton.snp.makeConstraints {
             $0.height.equalTo(Constant.space48)
-        }
-
-        activityIndicator.snp.makeConstraints {
-            $0.centerX.centerY.equalToSuperview()
-        }
-
-        indicatorLabel.snp.makeConstraints {
-            $0.centerX.equalToSuperview()
-            $0.top.equalTo(activityIndicator.snp.bottom).offset(Constant.space10)
         }
     }
 }

--- a/burstcamp/burstcamp/Presentation/Auth/SignUp/Blog/SignUpBlogViewController.swift
+++ b/burstcamp/burstcamp/Presentation/Auth/SignUp/Blog/SignUpBlogViewController.swift
@@ -48,7 +48,7 @@ final class SignUpBlogViewController: UIViewController {
             .sink { [weak self] _ in
                 let confirmAction = UIAlertAction(title: "예", style: .default) { _ in
                     skipConfirmSubject.send()
-                    self?.showIndicator(indicatorText: "가입 중")
+                    self?.showAnimatedActivityIndicatorView(description: "가입 중")
                 }
                 let cancelAction = UIAlertAction(title: "아니오", style: .destructive)
                 self?.showAlert(
@@ -61,7 +61,7 @@ final class SignUpBlogViewController: UIViewController {
         signUpBlogView.nextButton.tapPublisher
             .sink { [weak self] _ in
                 nextButtonSubject.send()
-                self?.showIndicator(indicatorText: "블로그 이름 확인 중")
+                self?.showAnimatedActivityIndicatorView(description: "블로그 이름 확인 중")
             }
             .store(in: &cancelBag)
 
@@ -85,14 +85,14 @@ final class SignUpBlogViewController: UIViewController {
         output.signUpWithNextButton
             .sink { [weak self] blogTitle in
                 DispatchQueue.main.async {
-                    self?.hideIndicator()
+                    self?.hideAnimatedActivityIndicatorView()
 
                     if blogTitle.isEmpty {
                         self?.showAlert(message: "블로그 주소를 확인해주세요.")
                     } else {
                         let confirmAction = UIAlertAction(title: "네", style: .default) { _ in
                             blogTitleConfirmSubject.send(blogTitle)
-                            self?.showIndicator(indicatorText: "가입 중")
+                            self?.showAnimatedActivityIndicatorView(description: "가입 중")
                         }
                         let cancelAction = UIAlertAction(title: "아니오", style: .destructive)
                         self?.showAlert(
@@ -106,7 +106,8 @@ final class SignUpBlogViewController: UIViewController {
 
         output.signUpWithBlogTitle
             .sink(receiveCompletion: { [weak self] result in
-                self?.hideIndicator()
+                self?.hideAnimatedActivityIndicatorView()
+
                 if case .failure = result {
                     self?.showAlert(message: "회원가입에 실패했습니다.")
                 }
@@ -118,7 +119,8 @@ final class SignUpBlogViewController: UIViewController {
 
         output.signUpWithSkipButton
             .sink(receiveCompletion: { [weak self] result in
-                self?.hideIndicator()
+                self?.hideAnimatedActivityIndicatorView()
+
                 if case .failure = result {
                     self?.showAlert(message: "회원가입에 실패했습니다.")
                 }
@@ -127,24 +129,5 @@ final class SignUpBlogViewController: UIViewController {
                 self?.coordinatorPublisher.send(.moveToTabBarFlow)
             })
             .store(in: &cancelBag)
-    }
-
-    private func showIndicator(indicatorText: String = "") {
-        DispatchQueue.main.async {
-            self.signUpBlogView.activityIndicator.startAnimating()
-            self.signUpBlogView.indicatorLabel.isHidden = false
-            self.signUpBlogView.indicatorLabel.text = indicatorText
-            self.signUpBlogView.nextButton.isEnabled = false
-            self.setUserInteraction(isEnabled: false)
-        }
-    }
-
-    private func hideIndicator() {
-        DispatchQueue.main.async {
-            self.signUpBlogView.activityIndicator.stopAnimating()
-            self.signUpBlogView.indicatorLabel.isHidden = true
-            self.signUpBlogView.nextButton.isEnabled = true
-            self.setUserInteraction(isEnabled: true)
-        }
     }
 }

--- a/burstcamp/burstcamp/Presentation/Coordinator/App/AppCoordinator.swift
+++ b/burstcamp/burstcamp/Presentation/Coordinator/App/AppCoordinator.swift
@@ -37,15 +37,6 @@ final class AppCoordinator: AppCoordinatorProtocol {
         navigationController.dismiss(animated: true)
     }
 
-    func displayIndicator() {
-        guard let authCoordinator = childCoordinators.first(
-            where: { $0 is AuthCoordinator }) as? AuthCoordinator
-        else {
-            return
-        }
-        authCoordinator.displayIndicator()
-    }
-
     func start() {
         animateLoadingView()
         let loginUseCase = dependencyFactory.createLoginUseCase()

--- a/burstcamp/burstcamp/Presentation/Coordinator/Auth/AuthCoordinator.swift
+++ b/burstcamp/burstcamp/Presentation/Coordinator/Auth/AuthCoordinator.swift
@@ -29,15 +29,6 @@ final class AuthCoordinator: AuthCoordinatorProtocol, GithubLogInCoordinator {
         self.dependencyFactory = dependencyFactory
     }
 
-    func displayIndicator() {
-        guard let logInViewController = navigationController.viewControllers.first(
-            where: { $0 is LogInViewController }) as? LogInViewController
-        else {
-            return
-        }
-        logInViewController.showIndicator()
-    }
-
     func start() {
         let loginViewModel = dependencyFactory.createLoginViewModel()
         let logInViewController = LogInViewController(viewModel: loginViewModel)

--- a/burstcamp/burstcamp/Presentation/Tab/Home/ViewController/HomeViewController.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/Home/ViewController/HomeViewController.swift
@@ -56,10 +56,6 @@ final class HomeViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         configureNavigationBar()
-        showAnimatedActivityIndicatorView(description: "Hello world")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-            self.hideAnimatedActivityIndicatorView()
-        }
     }
 
     private func configureUI() {}

--- a/burstcamp/burstcamp/Presentation/Tab/Home/ViewController/HomeViewController.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/Home/ViewController/HomeViewController.swift
@@ -56,6 +56,10 @@ final class HomeViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         configureNavigationBar()
+        showAnimatedActivityIndicatorView(description: "Hello world")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+            self.hideAnimatedActivityIndicatorView()
+        }
     }
 
     private func configureUI() {}

--- a/burstcamp/burstcamp/Presentation/Tab/MyPage/MyPage/View/MyPageView.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/MyPage/MyPage/View/MyPageView.swift
@@ -45,17 +45,6 @@ final class MyPageView: UIView, ContainCollectionView {
         $0.textColor = .systemGray2
     }
 
-    lazy var indicatorView = UIActivityIndicatorView().then {
-        $0.style = .medium
-    }
-
-    lazy var loadingLabel: UILabel = UILabel().then {
-        $0.text = "탈퇴 중이에요"
-        $0.font = .bold12
-        $0.textColor = .dynamicBlack
-        $0.isHidden = true
-    }
-
     lazy var myInfoEditButtonTapPublisher = myInfoEditButton.tapPublisher
     lazy var darkModeSwitchStatePublisher = darkModeSwitch.statePublisher
     lazy var notificationSwitchStatePublisher = notificationSwitch.statePublisher
@@ -102,17 +91,6 @@ final class MyPageView: UIView, ContainCollectionView {
             make.horizontalEdges.equalToSuperview().inset(Constant.Padding.horizontal)
             make.bottom.equalToSuperview()
         }
-
-        addSubview(indicatorView)
-        indicatorView.snp.makeConstraints { make in
-            make.center.equalToSuperview()
-        }
-
-        addSubview(loadingLabel)
-        loadingLabel.snp.makeConstraints { make in
-            make.centerX.equalToSuperview()
-            make.top.equalTo(indicatorView.snp.bottom).offset(Constant.space10)
-        }
     }
 
     private func configureCollectionView() {
@@ -132,7 +110,6 @@ final class MyPageView: UIView, ContainCollectionView {
                 )
             }
         )
-
         makeSnapshot()
     }
 

--- a/burstcamp/burstcamp/Presentation/Tab/MyPage/MyPage/ViewController/MyPageViewController.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/MyPage/MyPage/ViewController/MyPageViewController.swift
@@ -117,7 +117,7 @@ final class MyPageViewController: AppleAuthViewController {
 
         output.withdrawalStop
             .sink { [weak self] _ in
-                self?.hideIndicator()
+                self?.hideAnimatedActivityIndicatorView()
             }
             .store(in: &cancelBag)
 
@@ -150,7 +150,7 @@ final class MyPageViewController: AppleAuthViewController {
             title: Alert.yes,
             style: .default
         ) { [weak self] _ in
-            self?.showIndicator()
+            self?.showAnimatedActivityIndicatorView()
             self?.withdrawal()
         }
         let cancelAction = UIAlertAction(
@@ -168,29 +168,6 @@ final class MyPageViewController: AppleAuthViewController {
         self.withdrawalButtonPublisher.send(Void())
     }
 
-    private func showIndicator(text: String = "탈퇴 중이에요") {
-        DispatchQueue.main.async {
-            self.myPageView.indicatorView.startAnimating()
-            self.myPageView.loadingLabel.text = text
-            self.myPageView.loadingLabel.isHidden = false
-            self.setUserInteraction(isEnabled: false)
-        }
-    }
-
-    private func updateIndicator(text: String) {
-        DispatchQueue.main.async {
-            self.myPageView.loadingLabel.text = text
-        }
-    }
-
-    private func hideIndicator() {
-        DispatchQueue.main.async {
-            self.myPageView.indicatorView.stopAnimating()
-            self.myPageView.loadingLabel.isHidden = true
-            self.setUserInteraction(isEnabled: true)
-        }
-    }
-
     private func editMyInfoEdit(canEdit: Bool) {
         if canEdit {
             moveToMyPageEditScreen()
@@ -202,14 +179,14 @@ final class MyPageViewController: AppleAuthViewController {
 
     private func withdrawalWithApple(idTokenString: String, nonce: String) {
         Task { [weak self] in
-            self?.updateIndicator(text: "유저 정보 삭제 중")
+            self?.updateActivityOverlayDescriptionLabel("유저 정보 삭제 중")
             do {
                 try await viewModel.withdrawalWithApple(idTokenString: idTokenString, nonce: nonce)
                 self?.moveToAuthFlow()
             } catch {
                 self?.showAlert(message: "애플 로그인에 실패했습니다. \(error.localizedDescription)")
             }
-            self?.hideIndicator()
+            self?.hideAnimatedActivityIndicatorView()
         }
     }
 }
@@ -256,7 +233,7 @@ extension MyPageViewController {
 extension MyPageViewController {
     func withdrawalWithGithub(code: String) {
         Task { [weak self] in
-            updateIndicator(text: "유저 정보 삭제 중")
+            self?.updateActivityOverlayDescriptionLabel("유저 정보 삭제 중")
             do {
                 try await self?.viewModel.withdrawalWithGithub(code: code)
                 self?.moveToAuthFlow()

--- a/burstcamp/burstcamp/Service/Firebase/Firestore/BCFirestoreUserListener.swift
+++ b/burstcamp/burstcamp/Service/Firebase/Firestore/BCFirestoreUserListener.swift
@@ -29,7 +29,7 @@ final class BCFirestoreUserListener {
         let userPath = FirestoreCollection.user.path
         let documentReference = firestoreService.getDocumentReference(userPath, document: userUUID)
 
-        self.userListener = documentReference.addSnapshotListener{ [weak self] documentSnapshot, error in
+        self.userListener = documentReference.addSnapshotListener { [weak self] documentSnapshot, error in
             if let error = error {
                 self?.userListenerPublisher.send(completion: .failure(error))
             }

--- a/burstcamp/burstcamp/Util/Extension/UI/ViewController/UIViewController+.swift
+++ b/burstcamp/burstcamp/Util/Extension/UI/ViewController/UIViewController+.swift
@@ -101,6 +101,7 @@ extension UIViewController {
 
 // MARK: - Indicator
 
+// swiftlint:disable private_over_fileprivate
 fileprivate let overlayViewTag: Int = 998
 fileprivate let descriptionLabel: Int = 999
 fileprivate let activityIndicatorViewTag: Int = 1000
@@ -113,20 +114,22 @@ extension UIViewController {
         return view
     }
 
-    func showAnimatedActivityIndicatorView(description: String = "") {
+    public func showAnimatedActivityIndicatorView(description: String = "") {
+        guard !isShowingActivityIndicatorOverlay() else { return }
+
         let overlayView = createOverlayView()
 
         overlayContainerView.addSubview(overlayView)
 
         getActivityIndicatorView()?.startAnimating()
-      getDescriptionLabel()?.text = description
+        getDescriptionLabel()?.text = description
 
         overlayView.snp.makeConstraints {
             $0.edges.equalToSuperview()
         }
     }
 
-    func hideAnimatedActivityIndicatorView() {
+    public func hideAnimatedActivityIndicatorView() {
         guard let overlayView = getOverlayView(),
               let activityIndicatorView = getActivityIndicatorView(),
               let descriptionLabel = getDescriptionLabel()
@@ -143,6 +146,10 @@ extension UIViewController {
             descriptionLabel.removeFromSuperview()
             overlayView.removeFromSuperview()
         }
+    }
+
+    public func updateActivityOverlayDescriptionLabel(_ text: String) {
+        getDescriptionLabel()?.text = text
     }
 
     private func createOverlayView() -> UIView {


### PR DESCRIPTION
## 관련 이슈
<!--
이슈 번호 #000 작성  
ex) close #1 
--> 
- close #317 

## 내용
<!--
로직 설명  
필요시 스크린샷 첨부
--> 
- 기존에 각 ViewController에서 관리했던 indicator 한 번에 관리
- UIViewController+.swift 파일에 구현했습니다.
- `showAnimatedActivityIndicatorView(description: String = "")`를 사용해 indicator를 보여줍니다.
- `hideAnimatedActivityIndicatorView()`를 사용해 indicator를 멈춥니다.
- `updateActivityOverlayDescriptionLabel(_ text: String)`를 사용해 중간에 text를 업데이트 할 수 있습니다.

| 라이트 모드 | 다크 모드 |
| :---:|:---:|
|<img witdh = 300 src = "https://user-images.githubusercontent.com/71776532/215953503-04870e13-1c4e-491e-9390-5f64ff9b5068.gif" /> |<img witdh = 300 src = "https://user-images.githubusercontent.com/71776532/215953479-9ae15571-3481-49a9-bbaf-1a07efc60d71.gif" />| 

## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
- 일정 응답 시간이 지나면 자동으로 indicator가 꺼지고 Alert을 띄워줘야할 듯
