### PR TITLE
[Fix] iOS 15.0 에서 애플 로그인 - apple image 안 보이던 오류 수정

### DIFF
--- a/burstcamp/burstcamp/App/AppDelegate.swift
+++ b/burstcamp/burstcamp/App/AppDelegate.swift
@@ -27,6 +27,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             FeedRealmDataSource.shared.configure()
         }
         UserManager.shared.appStart()
+
         print("Auth.auth().currentUser?.uid 값이에오: ", Auth.auth().currentUser?.uid)
         print("키체인에 있던 유저의 UUID 값이에오: ", UserManager.shared.user.userUUID)
         configurePushNotification(application)

--- a/burstcamp/burstcamp/Presentation/Auth/LogIn/View/LogInView.swift
+++ b/burstcamp/burstcamp/Presentation/Auth/LogIn/View/LogInView.swift
@@ -28,12 +28,9 @@ final class LogInView: UIView {
         $0.font = UIFont.regular14
     }
 
-    let appleAuthButton = AuthButton(
-        text: "Apple로 로그인",
-        image: UIImage(systemName: "apple.logo")?.withTintColor(UIColor.dynamicWhite, renderingMode: .alwaysOriginal)
-    )
+    let appleAuthButton = AuthButton(kind: .apple)
 
-    let camperAuthButton = AuthButton(text: "Github으로 로그인", image: .github)
+    let camperAuthButton = AuthButton(kind: .github)
 
     private lazy var camperAuthLabel: UILabel = UILabel().then {
         $0.text = "Github 로그인을 통해 캠퍼인증을 하고 내 글을 등록할 수 있어요."

--- a/burstcamp/burstcamp/Presentation/Common/View/Button/AuthButton.swift
+++ b/burstcamp/burstcamp/Presentation/Common/View/Button/AuthButton.swift
@@ -7,14 +7,19 @@
 
 import UIKit
 
+enum AuthButtonKind {
+    case apple
+    case github
+}
+
 final class AuthButton: UIButton {
 
     init(
-        text: String,
-        image: UIImage?
+        kind: AuthButtonKind
     ) {
         super.init(frame: .zero)
 
+        let text = getText(kind: kind)
         var string = AttributedString(text)
         string.font = UIFont.extraBold14
         string.foregroundColor = .dynamicWhite
@@ -23,7 +28,7 @@ final class AuthButton: UIButton {
         configuration.attributedTitle = string
         configuration.titleAlignment = .center
 
-        configuration.image = image
+        configuration.image = getImage(kind: kind)
         configuration.imagePlacement = .leading
         configuration.imagePadding = 20
 
@@ -37,5 +42,24 @@ final class AuthButton: UIButton {
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    private func getText(kind: AuthButtonKind) -> String {
+        switch kind {
+        case .apple: return "Apple로 로그인"
+        case .github: return "Github으로 로그인"
+        }
+    }
+
+    private func getImage(kind: AuthButtonKind) -> UIImage? {
+        switch kind {
+        case .apple:
+            guard #available(iOS 16, *) else {
+                return UIImage(systemName: "applelogo")?.withTintColor(UIColor.dynamicWhite, renderingMode: .alwaysOriginal)
+            }
+            return UIImage(systemName: "apple.logo")?.withTintColor(UIColor.dynamicWhite, renderingMode: .alwaysOriginal)
+        case .github:
+            return .github
+        }
     }
 }

--- a/burstcamp/burstcamp/Service/Firebase/Auth/BCFirebaseAuthService.swift
+++ b/burstcamp/burstcamp/Service/Firebase/Auth/BCFirebaseAuthService.swift
@@ -17,7 +17,7 @@ protocol BCFirebaseAuthServiceProtocol {
 
     func loginWithApple(idTokenString: String, nonce: String) async throws -> String
     func withdrawalWithApple(idTokenString: String, nonce: String) async throws
-    
+
     func signOut() throws
 }
 

--- a/burstcamp/burstcamp/Service/Firebase/Auth/BCFirebaseAuthService.swift
+++ b/burstcamp/burstcamp/Service/Firebase/Auth/BCFirebaseAuthService.swift
@@ -17,6 +17,8 @@ protocol BCFirebaseAuthServiceProtocol {
 
     func loginWithApple(idTokenString: String, nonce: String) async throws -> String
     func withdrawalWithApple(idTokenString: String, nonce: String) async throws
+    
+    func signOut() throws
 }
 
 final class BCFirebaseAuthService: BCFirebaseAuthServiceProtocol {
@@ -55,6 +57,10 @@ final class BCFirebaseAuthService: BCFirebaseAuthServiceProtocol {
         let credential = OAuthProvider.credential(withProviderID: "apple.com", idToken: idTokenString, rawNonce: nonce)
         try await auth.currentUser?.reauthenticate(with: credential)
         try await auth.currentUser?.delete()
+        try auth.signOut()
+    }
+
+    func signOut() throws {
         try auth.signOut()
     }
 }


### PR DESCRIPTION
## 관련 이슈
<!--
이슈 번호 #000 작성  
ex) close #1 
--> 
- close #318 

## 내용
<!--
로직 설명  
필요시 스크린샷 첨부
--> 
- SFSymbols 버전 지원에 따른 오류
  <img width="306" alt="sfSymbol - apple image version check" src="https://user-images.githubusercontent.com/71776532/215956314-3a8099f0-e9ed-4591-9f24-ceaa002c368f.png">
- iOS 15.0에 대한 분기 처리
- iOS 16.0 이상에서도 이상 없음 확인

### 결과

| iPhone 13 pro iOS 15.0 수정 이전 | iPhone 13 pro iOS 15.0 수정 이후 | iPhone 14 pro max iOS 16.2 수정 이후 |
| :---:|:---:|:---:|
|<img witdh = 250 src = "https://user-images.githubusercontent.com/71776532/215956543-f5fe7d0f-c07a-4ec2-aff4-b8065cca9f57.png" /> |<img witdh = 250 src = "https://user-images.githubusercontent.com/71776532/215956550-f95c71d3-5b51-438a-a5db-8a7f3684aaca.png" />| <img witdh = 250 src = "https://user-images.githubusercontent.com/71776532/215956540-b8e686f6-735a-417a-8f2e-e782f01df56d.png" />|

## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
- SFSymbols 사용할 때 버전 확인을 생활화합시다.