### PR TITLE
[fix] profileImage가 삭제시 에러 처리

### DIFF
--- a/burstcamp/burstcamp/Domain/UseCase/Tab/MyPage/DefaultMyPageUseCase.swift
+++ b/burstcamp/burstcamp/Domain/UseCase/Tab/MyPage/DefaultMyPageUseCase.swift
@@ -20,9 +20,9 @@ final class DefaultMyPageUseCase: MyPageUseCase {
     }
 
     func withdrawalWithGithub(code: String) async throws {
-        let userUUID = UserManager.shared.user.userUUID
-        let isSuccess = try await loginRepository.withdrawalWithGithub(code: code, userUUID: userUUID)
-        try await imageRepository.deleteProfileImage(userUUID: userUUID)
+        let user = UserManager.shared.user
+        let isSuccess = try await loginRepository.withdrawalWithGithub(code: code, userUUID: user.userUUID)
+        try await deleteProfileImage(userUUID: user.userUUID, profileImageURL: user.profileImageURL)
         deleteLocalUser()
         if !isSuccess { throw MyPageUseCaseError.withdrawal }
     }
@@ -36,6 +36,12 @@ final class DefaultMyPageUseCase: MyPageUseCase {
         )
         deleteLocalUser()
         if !isSuccess { throw MyPageUseCaseError.withdrawal }
+    }
+
+    private func deleteProfileImage(userUUID: String, profileImageURL: String) async throws {
+        if !profileImageURL.hasPrefix("https://github.com/") {
+            try await imageRepository.deleteProfileImage(userUUID: userUUID)
+        }
     }
 
     // MARK: - 마이페이지 수정

--- a/burstcamp/burstcamp/Presentation/Tab/MyPage/MyPage/ViewController/MyPageViewController.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/MyPage/MyPage/ViewController/MyPageViewController.swift
@@ -236,12 +236,13 @@ extension MyPageViewController {
             self?.updateActivityOverlayDescriptionLabel("유저 정보 삭제 중")
             do {
                 try await self?.viewModel.withdrawalWithGithub(code: code)
+                self?.hideAnimatedActivityIndicatorView()
                 self?.moveToAuthFlow()
             } catch {
+                self?.hideAnimatedActivityIndicatorView()
                 debugPrint(error.localizedDescription)
                 showAlert(message: "유저 정보 삭제 중 에러가 발생했어요. \(error.localizedDescription)")
             }
-            self?.hideAnimatedActivityIndicatorView()
         }
     }
 }


### PR DESCRIPTION
## 관련 이슈
<!--
이슈 번호 #000 작성  
ex) close #1 
--> 
- close #321 

## 내용
<!--
로직 설명  
필요시 스크린샷 첨부
--> 
- 기존에 깃헙 프로필이미지를 쓰는 경우, Stroage에 이미지가 없는데 삭제 요청을 하게 되서 에러 메시지가 뜸
  - `!profileImageURL.hasPrefix("https://github.com/")` 이면 요청을 하지 않도록 수정 

## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 
- 에러 코드 응답을 따로 처리할 까 했는데, 그러면 실제로 데이터가 없을 때 에러를 발생 못 시킨다고 판단해 URL 여부에 따라 요청을 처리했습니다.

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
