### PR TITLE
[Feature] 클라우드 함수에서 추천 피드 설정

### DIFF
--- a/Firebase-Functions/functions/service/firestoreManager.js
+++ b/Firebase-Functions/functions/service/firestoreManager.js
@@ -35,6 +35,14 @@ export async function deleteRecommendFeeds() {
 		})
 }
 
+/**
+ * 1. 기존 추천피드를 삭제합니다.
+ * 2. 전체 피드의 FeedUUID를 가져옵니다
+ * 3. 각 피드의 최근 일주일 간 ScrapCount를 가져옵니다.
+ * 4. scrapCount가 top3인 [FeedUUID]를 리턴합니다.
+ * 5. 4의 [FeedUUID]를 추천 피드 DB에 등록합니다
+ */
+
 export async function updateRecommendFeedDB() {
 	await deleteRecommendFeeds()
 
@@ -45,6 +53,11 @@ export async function updateRecommendFeedDB() {
 
 }
 
+/**
+ * 전체 피드의 FeedUUID를 가져옵니다
+ * @returns {[String]} FeedUUID 배열을 리턴
+ */
+
 async function getFeedUUIDList() {
 	const querySnapshot = await feedRef.get()
 	return querySnapshot.docs.map((doc) => {
@@ -52,11 +65,17 @@ async function getFeedUUIDList() {
 	})
 }
 
+/**
+ * 각 피드의 최근 일주일간 ScrapCount를 수집합니다.
+ * @param {[String]} feedUUIList 
+ * @returns {[{feedUUID: String, count: Int}]} 각 피드의 UUID와 최근 일주일 간 count를 리턴
+ */
+
 async function getfeedWeeklyCountList(feedUUIDList) {
 	let aWeekAgoDate = getLastWeeksDate()
-	logger.log(aWeekAgoDate)
+	logger.log("추천 피드 스크랩 카운트 기준 날짜 - ", aWeekAgoDate)
 	return await Promise.all(feedUUIDList.map(async (feedUUID) => {
-		let weeklyCount = await countWeeklyScrapUser(feedUUID)
+		let weeklyCount = await countScrapUserSinceDate(aWeekAgoDate, feedUUID)
 		let feedWeeklyCount = {
 			feedUUID: feedUUID,
 			count: weeklyCount
@@ -65,13 +84,24 @@ async function getfeedWeeklyCountList(feedUUIDList) {
 	}))
 }
 
-async function countWeeklyScrapUser(feedUUID) {
-	let timestamp = getLastWeeksDate()
+/**
+ * FeedUUID를 통해 date 로부터 ScrapCount를 수집합니다.
+ * @param {Date, String} 
+ * @returns {Int} date로 부터 스크랩 count를 리턴
+ */
+
+async function countScrapUserSinceDate(date, feedUUID) {
+	let timestamp = date
 	const scrapUsersRef = feedRef.doc(feedUUID).collection('scrapUsers');
 	const query = scrapUsersRef.where('scrapDate', '>=', timestamp);
 	const snapshot = await query.count().get();
 	return snapshot.data().count
 }
+
+/**
+ * 지금으로부터 일주일 전 날짜를 구합니다.
+ * @returns {Date}
+ */
 
 function getLastWeeksDate() {
 	var oneWeekAgo = new Date();
@@ -79,7 +109,15 @@ function getLastWeeksDate() {
   return oneWeekAgo
 }
 
+/**
+ * FeedUUID & count 정보를 가진 객체를 내림차순 정렬합니다.
+ * 최상위 3개를 수집합니다. 이 때 count가 0 이면 수집하지 않습니다.
+ * @param {[{feedUUID: String, count: Int}]} feedUUID와count객체  
+ * @returns {[String]} 새로운 추천피드 [feedUUID]
+ */
+
 function getTopThreeFeedUUIDList(feedWeeklyCountList) {
+	let recommendFeedCountPolicy = 3
 	var topThreeFeedUUIDList = []
 
 	feedWeeklyCountList.sort((a, b) => {
@@ -88,18 +126,25 @@ function getTopThreeFeedUUIDList(feedWeeklyCountList) {
 
 	for (var i = 0;  i < feedWeeklyCountList.length; i++ ) {
 		if (feedWeeklyCountList[i].count != 0) {
-			topThreeFeedUUIDList.push(feedWeeklyCountList[i])
+			topThreeFeedUUIDList.push(feedWeeklyCountList[i].feedUUID)
 		}
-		if (topThreeFeedUUIDList.length == 3) {
+		if (topThreeFeedUUIDList.length == recommendFeedCountPolicy) {
 			break
 		}
 	}
 	return topThreeFeedUUIDList
 }
 
-async function updateNewRecommendFeedToDB(newRecommendFeedList) {
-	newRecommendFeedList.forEach(async (newFeed) => {
-		const newFeedRef =  feedRef.doc(newFeed.feedUUID)
+/**
+ * [feedUUID]를 받아 해당 feedUUID를 불러옵니다.
+ * feedUUID를 기반으로 피드 DB에서 피드를 불러옵니다.
+ * 불러온 피드를 추천피드에 저장합니다.
+ * @param {[String]} feedUUIDList
+ */
+
+async function updateNewRecommendFeedToDB(newRecommendFeedUUIDList) {
+	newRecommendFeedUUIDList.forEach(async (newFeedUUID) => {
+		const newFeedRef =  feedRef.doc(newFeedUUID)
 		const doc = await newFeedRef.get();
 		const newRecommendFeed = doc.data()
 		await recommendFeedRef.doc(newRecommendFeed.feedUUID).set(newRecommendFeed)


### PR DESCRIPTION
## 관련 이슈
<!--
이슈 번호 #000 작성  
ex) close #1 
--> 
- close #327 

## 내용
<!--
로직 설명  
필요시 스크린샷 첨부
--> 
- 일주일에 한 번 추천피드를 업데이트 합니다
- 로직
  - 기존 추천피드를 삭제합니다.
  - 전체 피드의 FeedUUID를 가져옵니다.
  - 각 피드의 최근 일주일 간 ScrapCount를 가져옵니다.
  - scrapCount top3를 정합니다. 이 때 count가 0 이면 포함하지 않습니다. -> 추천피드가 0~3개가 됩니다.
  - scarpCount top3 피드를 일반 피드에서 호출해, 추천 피드에 저장합니다.
- 정상 작동 확인했습니다.

## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 
- 상세 로직은 주석 달아놨으니 확인해주시면 됩니다.

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
