### PR TITLE
[Fix] 노말 피드 이미지 에러

### DIFF
--- a/burstcamp/burstcamp/Domain/UseCase/Tab/Home/DefaultHomeUseCase.swift
+++ b/burstcamp/burstcamp/Domain/UseCase/Tab/Home/DefaultHomeUseCase.swift
@@ -9,6 +9,8 @@ import Foundation
 
 final class DefaultHomeUseCase: HomeUseCase {
 
+    private let recommendFeedCount = 3
+
     private let feedRepository: FeedRepository
     private let userRepository: UserRepository
 
@@ -51,8 +53,7 @@ final class DefaultHomeUseCase: HomeUseCase {
     // MARK: RecommendFeed가 없는 경우 버스트 캠프 공지
 
     private func addBurstcampNoticeIfNeed(recommendFeedList: [Feed]) -> [Feed] {
-        let targetCount = 4
-        let noticeFeed = feedRepository.createMockUpRecommendFeedList(count: targetCount - recommendFeedList.count)
+        let noticeFeed = feedRepository.createMockUpRecommendFeedList(count: self.recommendFeedCount - recommendFeedList.count)
         return recommendFeedList + noticeFeed
     }
 

--- a/burstcamp/burstcamp/Presentation/Common/View/NormalFeedCell/Main/NormalFeedCellMain.swift
+++ b/burstcamp/burstcamp/Presentation/Common/View/NormalFeedCell/Main/NormalFeedCellMain.swift
@@ -117,4 +117,8 @@ extension NormalFeedCellMain {
         }
         self.setThumbnailImage(urlString: feed.thumbnailURL)
     }
+
+    func resetThumbnailImage() {
+        thumbnailImageView.image = nil
+    }
 }

--- a/burstcamp/burstcamp/Presentation/Common/View/NormalFeedCell/Main/NormalFeedCellMain.swift
+++ b/burstcamp/burstcamp/Presentation/Common/View/NormalFeedCell/Main/NormalFeedCellMain.swift
@@ -98,8 +98,10 @@ class NormalFeedCellMain: UIView {
         } else if !hasThumbnailImage && newFeedHaveImage(urlString) {
             updateThumbnailImageView()
             updateTitleLabel()
-            self.thumbnailImageView.setImage(urlString: urlString)
             hasThumbnailImage = true
+        }
+        if newFeedHaveImage(urlString) {
+            self.thumbnailImageView.setImage(urlString: urlString)
         }
     }
 

--- a/burstcamp/burstcamp/Presentation/Common/View/NormalFeedCell/NormalFeedCell.swift
+++ b/burstcamp/burstcamp/Presentation/Common/View/NormalFeedCell/NormalFeedCell.swift
@@ -35,6 +35,7 @@ final class NormalFeedCell: UICollectionViewCell {
     override func prepareForReuse() {
         super.prepareForReuse()
         userInfoView.reset()
+        mainView.resetThumbnailImage()
         cancelBag = Set<AnyCancellable>()
     }
 

--- a/burstcamp/burstcamp/Presentation/Common/View/RecommendCell/RecommendFeedCell.swift
+++ b/burstcamp/burstcamp/Presentation/Common/View/RecommendCell/RecommendFeedCell.swift
@@ -38,6 +38,11 @@ final class RecommendFeedCell: UICollectionViewCell {
         super.init(coder: coder)
     }
 
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        userView.resetUserImage()
+    }
+
     private func configureUI() {
         contentView.addSubview(stackView)
         stackView.addArrangedSubViews([titleLabel, userView])
@@ -68,9 +73,6 @@ final class RecommendFeedCell: UICollectionViewCell {
         } else {
             isUserInteractionEnabled = true
         }
-    }
-
-    private func setUserImageToBurstcamper() {
     }
 }
 

--- a/burstcamp/burstcamp/Presentation/Common/View/RecommendCell/RecommendFeedUserView.swift
+++ b/burstcamp/burstcamp/Presentation/Common/View/RecommendCell/RecommendFeedUserView.swift
@@ -69,4 +69,8 @@ extension RecommendFeedUserView {
         nicknameLabel.text = feedWriter.nickname
         blogTitleLabel.text = feedWriter.blogTitle
     }
+
+    func resetUserImage() {
+        profileImageView.image = nil
+    }
 }


### PR DESCRIPTION
## 관련 이슈
<!--
이슈 번호 #000 작성  
ex) close #1 
--> 
- close #336

## 내용
<!--
로직 설명  
필요시 스크린샷 첨부
--> 
- `setImage` 위치를 수정했습니다.
- 노말 피드 & 추천피드 prepare For Reuse에서 피드를 초기화 해줍니다.
- 추천피드 개수를 수정했습니다. 4 -> 3


## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
