### PR TITLE
[Feature] 피드 디테일 알람 시 deep link

### DIFF
--- a/Firebase-Functions/functions/index.js
+++ b/Firebase-Functions/functions/index.js
@@ -70,3 +70,11 @@ export const testCheckAlgorithm = https
 			isFinish: true
 		}
 })
+
+export const testMessaging = https
+.onRequest(async (context) => {
+	await sendNotification()
+	return {
+		isFinish: true
+	}
+})

--- a/Firebase-Functions/functions/service/apnsManager.js
+++ b/Firebase-Functions/functions/service/apnsManager.js
@@ -13,10 +13,6 @@ import { getMessaging } from 'firebase-admin/messaging';
 export async function sendNotification() {
     const userUUIDs = await getUsersIsPushOnTrue()
     const recentFeed = await getRecentFeed()
-    const writerUUID = recentFeed['writerUUID']
-    const writer = await getUser(writerUUID)
-    logger.log('작성자UUID에오', writerUUID)
-    logger.log('작성자에오', writer)
 
     const tokens = await Promise.all(
         userUUIDs.map(userUUID => {
@@ -26,7 +22,7 @@ export async function sendNotification() {
 
     logger.log('보낼 토큰들을 만들었어요', validTokens)
 
-    sendMessage(validTokens, recentFeed, writer)
+    sendMessage(validTokens, recentFeed)
 }
 
 
@@ -34,11 +30,10 @@ export async function sendNotification() {
 * 메세지를 한번에 모든 token에게 보낸다.
 * @param {[String]} token 
 * @param {Feed} feed 
-* @param {User} writer 
 */
-export async function sendMessage(tokens, feed, writer) {
+export async function sendMessage(tokens, feed) {
     logger.log('실행하는중~~~~~~~')
-    const message = makeMessage(tokens, feed, writer)
+    const message = makeMessage(tokens, feed)
     const messaging = getMessaging()
     messaging.sendMulticast(message)
     .then((response) => {
@@ -57,16 +52,16 @@ export async function sendMessage(tokens, feed, writer) {
 * @param {Feed} feed 
 * @param {User} writer 
 */
-function makeMessage(fcmTokens, feed, writer) {
-        logger.log('Feed 작성자에오, ', writer)
+function makeMessage(fcmTokens, feed) {
+        logger.log('Feed 작성자에오, ', feed.writerNickname)
         const title = feed['title']
         const feedUUID = feed['feedUUID']
-        const nickname = writer['nickname']
+        const nickname = feed['writerNickname']
         const body = title + ' 📣 by ' + nickname
     
         const message = {
             notification: {
-                title: '오늘의 피드를 확인해보세요 💙',
+                title: '오늘의 최신 피드를 확인해보세요 💙',
                 body: body
             },
             data: { feedUUID: feedUUID },

--- a/burstcamp/burstcamp/Data/Repositories/FeedRepository/DefaultFeedRepository.swift
+++ b/burstcamp/burstcamp/Data/Repositories/FeedRepository/DefaultFeedRepository.swift
@@ -81,7 +81,14 @@ final class DefaultFeedRepository: FeedRepository {
         }
     }
 
-    // MARK: 피드 스크랩
+    // MARK: - 피드 호출
+    func fetchFeed(by feedUUID: String) async throws -> Feed {
+        let feedAPIModel = try await bcFirestoreService.fetchFeed(feedUUID: feedUUID)
+        return Feed(feedAPIModel: feedAPIModel)
+    }
+
+    // MARK: - 피드 스크랩
+
     func scrapFeed(_ feed: Feed, userUUID: String) async throws -> Feed {
         let scrapedFeed = feed.getScrapFeed()
         try await bcFirestoreService.scrapFeed(scrapedFeed.toScrapFeedAPIModel(), with: userUUID)

--- a/burstcamp/burstcamp/Data/Repositories/FeedRepository/MockUpFeedRepository.swift
+++ b/burstcamp/burstcamp/Data/Repositories/FeedRepository/MockUpFeedRepository.swift
@@ -41,6 +41,10 @@ extension MockUpFeedRepository {
         throw MockUpFeedRepositoryError.noImplementation
     }
 
+    func fetchFeed(by feedUUID: String) async throws -> Feed {
+        throw MockUpFeedRepositoryError.noImplementation
+    }
+
     func scrapFeed(_ feed: Feed, userUUID: String) async throws -> Feed {
         throw MockUpFeedRepositoryError.noImplementation
     }

--- a/burstcamp/burstcamp/Domain/Interfaces/FeedRepository/FeedRepository.swift
+++ b/burstcamp/burstcamp/Domain/Interfaces/FeedRepository/FeedRepository.swift
@@ -14,6 +14,8 @@ protocol FeedRepository {
     func fetchRecentScrapFeed(userUUID: String) async throws -> [Feed]
     func fetchMoreScrapFeed(userUUID: String) async throws -> [Feed]
 
+    func fetchFeed(by feedUUID: String) async throws -> Feed
+
     func scrapFeed(_ feed: Feed, userUUID: String) async throws -> Feed
     func unScrapFeed(_ feed: Feed, userUUID: String) async throws -> Feed
 

--- a/burstcamp/burstcamp/Domain/UseCase/Tab/Detail/DefaultFeedDetailUseCase.swift
+++ b/burstcamp/burstcamp/Domain/UseCase/Tab/Detail/DefaultFeedDetailUseCase.swift
@@ -15,6 +15,10 @@ final class DefaultFeedDetailUseCase: FeedDetailUseCase {
         self.feedRepository = feedRepository
     }
 
+    func fetchFeed(by feedUUID: String) async throws -> Feed {
+        
+    }
+    
     func scrapFeed(_ feed: Feed, userUUID: String) async throws -> Feed {
         return feed.isScraped
         ? try await feedRepository.unScrapFeed(feed, userUUID: userUUID)

--- a/burstcamp/burstcamp/Domain/UseCase/Tab/Detail/DefaultFeedDetailUseCase.swift
+++ b/burstcamp/burstcamp/Domain/UseCase/Tab/Detail/DefaultFeedDetailUseCase.swift
@@ -16,9 +16,9 @@ final class DefaultFeedDetailUseCase: FeedDetailUseCase {
     }
 
     func fetchFeed(by feedUUID: String) async throws -> Feed {
-        
+        return try await feedRepository.fetchFeed(by: feedUUID)
     }
-    
+
     func scrapFeed(_ feed: Feed, userUUID: String) async throws -> Feed {
         return feed.isScraped
         ? try await feedRepository.unScrapFeed(feed, userUUID: userUUID)

--- a/burstcamp/burstcamp/Domain/UseCase/Tab/Detail/FeedDetailUseCase.swift
+++ b/burstcamp/burstcamp/Domain/UseCase/Tab/Detail/FeedDetailUseCase.swift
@@ -8,5 +8,7 @@
 import Foundation
 
 protocol FeedDetailUseCase {
+    func fetchFeed(by feedUUID: String) async throws -> Feed
+
     func scrapFeed(_ feed: Feed, userUUID: String) async throws -> Feed
 }

--- a/burstcamp/burstcamp/Presentation/Tab/Detail/ViewController/FeedDetailViewController.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/Detail/ViewController/FeedDetailViewController.swift
@@ -95,7 +95,12 @@ final class FeedDetailViewController: UIViewController {
 
         feedDetailOutput.feedDidUpdate
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] feed in
+            .sink { [weak self] completion in
+                switch completion {
+                case .failure(let error): self?.showAlert(message: "피드를 불러오는 중 에러가 발생했어요. \(error.localizedDescription)")
+                case .finished: return
+                }
+            } receiveValue: { [weak self] feed in
                 self?.handleFeedDidUpdate(feed)
             }
             .store(in: &cancelBag)

--- a/burstcamp/burstcamp/Presentation/Tab/Detail/ViewController/FeedDetailViewController.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/Detail/ViewController/FeedDetailViewController.swift
@@ -140,7 +140,6 @@ final class FeedDetailViewController: UIViewController {
 
     private func handleFeedDidUpdate(_ feed: Feed?) {
         guard let feed = feed else {
-            showAlert(message: "Feed 로드 중 에러가 발생했어요")
             return
         }
         scrapButton.isOn = feed.isScraped

--- a/burstcamp/burstcamp/Presentation/Tab/Detail/ViewModel/FeedDetailViewModel.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/Detail/ViewModel/FeedDetailViewModel.swift
@@ -25,6 +25,7 @@ final class FeedDetailViewModel {
     /// DeepLink를 통해서 진입할 때 호출하는 initializer
     convenience init(feedDetailUseCase: FeedDetailUseCase, feedUUID: String) {
         self.init(feedDetailUseCase: feedDetailUseCase)
+        handleDeepLinkFeed(feedUUID: feedUUID)
     }
 
     struct Input {

--- a/burstcamp/burstcamp/Presentation/Tab/Detail/ViewModel/FeedDetailViewModel.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/Detail/ViewModel/FeedDetailViewModel.swift
@@ -87,6 +87,5 @@ final class FeedDetailViewModel {
     }
 
     private func handleDeepLinkFeed(feedUUID: String) {
-        
     }
 }

--- a/burstcamp/burstcamp/Presentation/Tab/Detail/ViewModel/FeedDetailViewModel.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/Detail/ViewModel/FeedDetailViewModel.swift
@@ -25,7 +25,7 @@ final class FeedDetailViewModel {
     /// DeepLink를 통해서 진입할 때 호출하는 initializer
     convenience init(feedDetailUseCase: FeedDetailUseCase, feedUUID: String) {
         self.init(feedDetailUseCase: feedDetailUseCase)
-        // feed UUID로 feed 호출
+        handleDeepLinkFeed(feedUUID: feedUUID)
     }
 
     struct Input {
@@ -84,5 +84,9 @@ final class FeedDetailViewModel {
         let updatedFeed = try await feedDetailUseCase.scrapFeed(feed, userUUID: userUUID)
         feedPublisher.value = updatedFeed
         return updatedFeed
+    }
+
+    private func handleDeepLinkFeed(feedUUID: String) {
+        
     }
 }


### PR DESCRIPTION
## 관련 이슈
<!--
이슈 번호 #000 작성  
ex) close #1 
--> 
- close #322 

## 내용
<!--
로직 설명  
필요시 스크린샷 첨부
--> 
- 기존에 리팩토링하면서 제거했던 딥링크를 복구했습니다.
- function함수에 소소한 수정이 있습니다.
  - 기존 : feedUUID로  feed 호출 -> writer 호출 -> feed + writer 보냄
  - 수정 후 : feeUUID로 feed 호출 -> feed에 writer 정보가 있으므로 그냥 보냄
  - shell에서 `testMessaging()` 을 통해 바로 알람 확인 가능
- 현재 ViewController에서 언래핑 시 예외처리가 필요합니다.
  - FeedDetail ViewModel에서 CurrentValueSubject를 사용해 Feed = nil로 초기값이 설정됩니다.
  - 딥링크로 접근시 초기값 nil이 방출되고, feedUUID로 호출한 두 번째 Feed가 방출됩니다.
  - 이에 따라 viewController에서 언래핑시 에러가 발생합니다. 우선은 nil인 경우 그냥 return으로 처리했습니다.
  - 동작에는 이상이 없지만, 언래핑 과정에 따른 예외처리가 없어서 아쉽네요.


## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
