### PR TITLE
[Fix] 유저 회원가입시 DB 업데이트

### DIFF
--- a/Firebase-Functions/functions/index.js
+++ b/Firebase-Functions/functions/index.js
@@ -1,5 +1,5 @@
 import { initializeApp, getApps } from 'firebase-admin/app';
-import { pubsub, https } from 'firebase-functions';
+import { pubsub, https, logger } from 'firebase-functions';
 import { getBlogTitle } from './service/feedAPI.js';
 import { updateFeedDB, updateRecommendFeedDB, updateFeedDBWhenSignup } from './service/firestoreManager.js'
 import { sendNotification } from './service/apnsManager.js'
@@ -19,8 +19,10 @@ export const scheduledUpdateRecommendFeedDB = pubsub.schedule('every monday 00:0
 	updateRecommendFeedDB()
 })
 
-export const updateFeedWithNewUser = https.onCall(async (context) => {
-	updateFeedDBWhenSignup()
+export const updateFeedWithNewUser = https.onCall(async (data, context) => {
+	const userUUID = data.userUUID
+	const blogURL = data.blogURL
+	updateFeedDBWhenSignup(userUUID, blogURL)
 })
 
 export const fetchBlogTitle = https.onCall(async (data, context) => {

--- a/Firebase-Functions/functions/index.js
+++ b/Firebase-Functions/functions/index.js
@@ -1,7 +1,7 @@
 import { initializeApp, getApps } from 'firebase-admin/app';
 import { pubsub, https } from 'firebase-functions';
 import { getBlogTitle } from './service/feedAPI.js';
-import { updateFeedDB, updateRecommendFeedDB, deleteRecommendFeeds } from './service/firestoreManager.js'
+import { updateFeedDB, updateRecommendFeedDB, updateFeedDBWhenSignup } from './service/firestoreManager.js'
 import { sendNotification } from './service/apnsManager.js'
 import { deleteUserInfo } from './service/withdrawalManager.js'
 import { createMockUpUser } from './service/test/mockUpService.js';
@@ -19,8 +19,8 @@ export const scheduledUpdateRecommendFeedDB = pubsub.schedule('every monday 00:0
 	updateRecommendFeedDB()
 })
 
-export const updateFeedDBWhenSignup = https.onCall(async (context) => {
-	updateFeedDB()
+export const updateFeedWithNewUser = https.onCall(async (context) => {
+	updateFeedDBWhenSignup()
 })
 
 export const fetchBlogTitle = https.onCall(async (data, context) => {

--- a/Firebase-Functions/functions/service/firestoreManager.js
+++ b/Firebase-Functions/functions/service/firestoreManager.js
@@ -24,6 +24,17 @@ export async function updateFeedDB() {
 	})
 }
 
+export async function updateFeedDBWhenSignup(userUUID, blogURL) {
+	logger.log("회원 가입에 따른 DB Update - Blog URL : ", blogURL);
+	const doc = await userRef.doc(userUUID).get();
+	const userData = doc.data();
+	if (blogURL === '') { return }
+
+	const rssURL = convertURL(blogURL);
+	const parsedRss = await fetchParsedRSS(rssURL);
+	await updateFeedDBFromSingleBlog(parsedRss, userData);
+}
+
 export async function deleteRecommendFeeds() {
 	await recommendFeedRef
 		.get()

--- a/burstcamp/burstcamp/Data/Repositories/UserRepository/DefaultUserRepository.swift
+++ b/burstcamp/burstcamp/Data/Repositories/UserRepository/DefaultUserRepository.swift
@@ -74,7 +74,14 @@ final class DefaultUserRepository: UserRepository {
         )
     }
 
-    // MARK: Guest
+    // MARK: - 가입시 블로그 업데이트
+
+    func updateBlog(with signUpUserUUID: String, blogURL: String) async throws {
+        try await bcFirebaseFunctionService.updateBlog(with: signUpUserUUID, blogURL: blogURL)
+    }
+
+    // MARK: - Guest
+
     func saveGuest(userUUID: String) async throws -> User {
         let nickname = try getNickname(userUUID: userUUID)
         let guestUser = User(userUUID: userUUID, nickname: nickname)

--- a/burstcamp/burstcamp/Domain/Interfaces/UserRepository/UserRepository.swift
+++ b/burstcamp/burstcamp/Domain/Interfaces/UserRepository/UserRepository.swift
@@ -15,6 +15,8 @@ protocol UserRepository {
     func removeUser(_ user: User) async throws
     func saveFCMToken(_ token: String, to userUUID: String) async throws
 
+    func updateBlog(with signUpUserUUID: String, blogURL: String) async throws
+
     func saveGuest(userUUID: String) async throws -> User
     func isNicknameExist(_ nickname: String) async throws -> Bool
 }

--- a/burstcamp/burstcamp/Domain/UseCase/Auth/SignUp/DefaultSignUpUseCase.swift
+++ b/burstcamp/burstcamp/Domain/UseCase/Auth/SignUp/DefaultSignUpUseCase.swift
@@ -64,6 +64,10 @@ final class DefaultSignUpUseCase: SignUpUseCase {
         try await userRepository.saveUser(user)
         KeyChainManager.save(user: user)
         UserManager.shared.setUser(user)
+
+        if !user.blogURL.isEmpty {
+            try await userRepository.updateBlog(with: user.userUUID, blogURL: user.blogURL)
+        }
     }
 
     func saveFCMToken(_ token: String, to userUUID: String) async throws {

--- a/burstcamp/burstcamp/Domain/UseCase/Auth/SignUp/DefaultSignUpUseCase.swift
+++ b/burstcamp/burstcamp/Domain/UseCase/Auth/SignUp/DefaultSignUpUseCase.swift
@@ -64,10 +64,6 @@ final class DefaultSignUpUseCase: SignUpUseCase {
         try await userRepository.saveUser(user)
         KeyChainManager.save(user: user)
         UserManager.shared.setUser(user)
-
-        if !user.blogURL.isEmpty {
-            try await userRepository.updateBlog(with: user.userUUID, blogURL: user.blogURL)
-        }
     }
 
     func saveFCMToken(_ token: String, to userUUID: String) async throws {

--- a/burstcamp/burstcamp/Presentation/Auth/SignUp/Blog/SignUpBlogViewController.swift
+++ b/burstcamp/burstcamp/Presentation/Auth/SignUp/Blog/SignUpBlogViewController.swift
@@ -134,12 +134,16 @@ final class SignUpBlogViewController: UIViewController {
     }
 
     private func enableSignupButton() {
-        signUpBlogView.skipButton.isEnabled = true
-        signUpBlogView.nextButton.isEnabled = true
+        DispatchQueue.main.async {
+            self.signUpBlogView.skipButton.isEnabled = true
+            self.signUpBlogView.nextButton.isEnabled = true
+        }
     }
 
     private func disableSignupButton() {
-        signUpBlogView.skipButton.isEnabled = false
-        signUpBlogView.nextButton.isEnabled = false
+        DispatchQueue.main.async {
+            self.signUpBlogView.skipButton.isEnabled = false
+            self.signUpBlogView.nextButton.isEnabled = false
+        }
     }
 }

--- a/burstcamp/burstcamp/Presentation/Auth/SignUp/Blog/SignUpBlogViewController.swift
+++ b/burstcamp/burstcamp/Presentation/Auth/SignUp/Blog/SignUpBlogViewController.swift
@@ -67,7 +67,7 @@ final class SignUpBlogViewController: UIViewController {
             .store(in: &cancelBag)
 
         let input = SignUpBlogViewModel.Input(
-            blogAddressTextFieldDidEdit: signUpBlogView.blogTextField.textPublisher,
+            blogAddressTextFieldDidEdit: signUpBlogView.blogTextField.textChangedPublisher,
             nextButtonDidTap: nextButtonSubject,
             skipConfirmDidTap: skipConfirmSubject,
             blogTitleConfirmDidTap: blogTitleConfirmSubject

--- a/burstcamp/burstcamp/Presentation/Auth/SignUp/Blog/SignUpBlogViewController.swift
+++ b/burstcamp/burstcamp/Presentation/Auth/SignUp/Blog/SignUpBlogViewController.swift
@@ -45,6 +45,7 @@ final class SignUpBlogViewController: UIViewController {
 
         signUpBlogView.skipButton.tapPublisher
             .sink { [weak self] _ in
+                self?.hideKeyboard()
                 let confirmAction = UIAlertAction(title: "예", style: .default) { _ in
                     skipConfirmSubject.send()
                     self?.showAnimatedActivityIndicatorView(description: "가입 중")
@@ -60,6 +61,7 @@ final class SignUpBlogViewController: UIViewController {
 
         signUpBlogView.nextButton.tapPublisher
             .sink { [weak self] _ in
+                self?.hideKeyboard()
                 nextButtonSubject.send()
                 self?.showAnimatedActivityIndicatorView(description: "블로그 이름 확인 중")
                 self?.disableSignupButton()
@@ -131,6 +133,12 @@ final class SignUpBlogViewController: UIViewController {
                 self?.coordinatorPublisher.send(.moveToTabBarFlow)
             })
             .store(in: &cancelBag)
+    }
+
+    private func hideKeyboard() {
+        DispatchQueue.main.async {
+            self.view.endEditing(true)
+        }
     }
 
     private func enableSignupButton() {

--- a/burstcamp/burstcamp/Presentation/Auth/SignUp/Blog/SignUpBlogViewController.swift
+++ b/burstcamp/burstcamp/Presentation/Auth/SignUp/Blog/SignUpBlogViewController.swift
@@ -110,8 +110,8 @@ final class SignUpBlogViewController: UIViewController {
             .sink(receiveCompletion: { [weak self] result in
                 self?.hideAnimatedActivityIndicatorView()
                 self?.enableSignupButton()
-                if case .failure = result {
-                    self?.showAlert(message: "회원가입에 실패했습니다.")
+                if case .failure(let error) = result {
+                    self?.showAlert(message: "회원가입에 실패했습니다. \(error.localizedDescription)")
                 }
             }, receiveValue: { [weak self] _ in
                 self?.hideAnimatedActivityIndicatorView()
@@ -124,8 +124,8 @@ final class SignUpBlogViewController: UIViewController {
             .sink(receiveCompletion: { [weak self] result in
                 self?.hideAnimatedActivityIndicatorView()
                 self?.enableSignupButton()
-                if case .failure = result {
-                    self?.showAlert(message: "회원가입에 실패했습니다.")
+                if case .failure(let error) = result {
+                    self?.showAlert(message: "회원가입에 실패했습니다. \(error.localizedDescription)")
                 }
             }, receiveValue: { [weak self] _ in
                 self?.hideAnimatedActivityIndicatorView()

--- a/burstcamp/burstcamp/Presentation/Auth/SignUp/Blog/SignUpBlogViewModel.swift
+++ b/burstcamp/burstcamp/Presentation/Auth/SignUp/Blog/SignUpBlogViewModel.swift
@@ -103,7 +103,7 @@ final class SignUpBlogViewModel {
 
                     if blogTitle.isEmpty { assert(user.blogURL.isEmpty) }
                     try await self?.signUpUseCase.signUp(user)
-                    self?.saveFCMToken()
+                    try await self?.saveFCMToken(userUUID: userUUID)
                     promise(.success(user))
                 } catch {
                     print(error)
@@ -114,11 +114,8 @@ final class SignUpBlogViewModel {
         .eraseToAnyPublisher()
     }
 
-    private func saveFCMToken() {
+    private func saveFCMToken(userUUID: String) async throws {
         guard let fcmToken = UserDefaultsManager.fcmToken() else { return }
-        let userUUID = UserManager.shared.user.userUUID
-        Task { [weak self] in
-            try await self?.signUpUseCase.saveFCMToken(fcmToken, to: userUUID)
-        }
+        try await signUpUseCase.saveFCMToken(fcmToken, to: userUUID)
     }
 }

--- a/burstcamp/burstcamp/Presentation/Auth/SignUp/CamperID/SignUpCamperIDViewController.swift
+++ b/burstcamp/burstcamp/Presentation/Auth/SignUp/CamperID/SignUpCamperIDViewController.swift
@@ -46,7 +46,7 @@ final class SignUpCamperIDViewController: UIViewController {
 
     private func bind() {
         let input = SignUpCamperIDViewModel.Input(
-            camperIDTextFieldDidEdit: signUpCamperIDView.idTextField.textPublisher,
+            camperIDTextFieldDidEdit: signUpCamperIDView.idTextField.textChangedPublisher,
             nextButtonDidTap: signUpCamperIDView.nextButton.tapPublisher
         )
 

--- a/burstcamp/burstcamp/Presentation/Tab/MyPage/Edit/View/MyPageEditView.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/MyPage/Edit/View/MyPageEditView.swift
@@ -91,8 +91,8 @@ final class MyPageEditView: UIView {
     }
 
     lazy var cameraButtonTapPublisher = cameraButton.tapPublisher
-    lazy var nickNameTextFieldTextPublisher = nickNameTextField.textPublisher
-    lazy var blogLinkTextFieldTextPublisher = blogLinkTextField.textPublisher
+    lazy var nickNameTextFieldTextPublisher = nickNameTextField.textEditingEndPublisher
+    lazy var blogLinkTextFieldTextPublisher = blogLinkTextField.textEditingEndPublisher
     lazy var finishEditButtonTapPublisher = finishEditButton.tapPublisher
 
     // MARK: - Initializer

--- a/burstcamp/burstcamp/Util/Extension/Combine/UIControl+Combine.swift
+++ b/burstcamp/burstcamp/Util/Extension/Combine/UIControl+Combine.swift
@@ -63,7 +63,14 @@ extension UIControl {
 }
 
 extension UITextField {
-    var textPublisher: AnyPublisher<String, Never> {
+    var textChangedPublisher: AnyPublisher<String, Never> {
+        controlPublisher(for: .editingChanged)
+            .compactMap { $0 as? UITextField }
+            .compactMap { $0.text }
+            .eraseToAnyPublisher()
+    }
+
+    var textEditingEndPublisher: AnyPublisher<String, Never> {
         controlPublisher(for: .editingDidEnd)
             .compactMap { $0 as? UITextField }
             .compactMap { $0.text }

--- a/modules/BCFirebase/BCFirebase/FireFunction/BCFirebaseFunctionService.swift
+++ b/modules/BCFirebase/BCFirebase/FireFunction/BCFirebaseFunctionService.swift
@@ -52,10 +52,29 @@ public final class BCFirebaseFunctionService {
         // TODO: 유저 업데이트 함수 호출
         debugPrint("유저 DB 업데이트 팡숀")
     }
+    
+    public func updateBlog(with signUpUserUUID: String, blogURL: String) async throws {
+        let result = try await functions
+            .httpsCallable(FunctionField.updateFeedWithNewUser)
+            .call([
+                FunctionField.userUUID: signUpUserUUID,
+                FunctionField.blogURL: blogURL
+            ])
+        
+        if let data = result.data as? [String: Any],
+           let isFinish = data[FunctionField.isFinish] as? Bool {
+            if !isFinish {
+                throw FireStorageError.userSignUp
+            }
+        } else {
+            throw FireStorageError.userSignUp
+        }
+    }
 }
 
 extension BCFirebaseFunctionService {
     enum FunctionField {
+        static let updateFeedWithNewUser = "updateFeedWithNewUser"
         static let fetchBlogTitle = "fetchBlogTitle"
         static let deleteUser = "deleteUser"
         static let blogURL = "blogURL"

--- a/modules/BCFirebase/BCFirebase/FireFunction/BCFirebaseFunctionService.swift
+++ b/modules/BCFirebase/BCFirebase/FireFunction/BCFirebaseFunctionService.swift
@@ -54,21 +54,12 @@ public final class BCFirebaseFunctionService {
     }
     
     public func updateBlog(with signUpUserUUID: String, blogURL: String) async throws {
-        let result = try await functions
+        _ = try await functions
             .httpsCallable(FunctionField.updateFeedWithNewUser)
             .call([
                 FunctionField.userUUID: signUpUserUUID,
                 FunctionField.blogURL: blogURL
             ])
-        
-        if let data = result.data as? [String: Any],
-           let isFinish = data[FunctionField.isFinish] as? Bool {
-            if !isFinish {
-                throw FireStorageError.userSignUp
-            }
-        } else {
-            throw FireStorageError.userSignUp
-        }
     }
 }
 

--- a/modules/BCFirebase/BCFirebase/FireStorage/FireStorageError.swift
+++ b/modules/BCFirebase/BCFirebase/FireStorage/FireStorageError.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 public enum FireStorageError: LocalizedError {
+    case userSignUp
     case dataUpload
     case URLDownload
     case deleteError
@@ -16,6 +17,7 @@ public enum FireStorageError: LocalizedError {
 extension FireStorageError {
     public var errorDescription: String? {
         switch self {
+        case .userSignUp: return "DB에 블로그 업데이트 중 에러가 발생했습니다"
         case .dataUpload: return "데이터 업로드 중 에러가 발생했습니다."
         case .URLDownload: return "서버에서 URL을 받아오던 중 에러가 발생했습니다."
         case .deleteError: return "서버에서 데이터 삭제 중 에러가 발생했습니다."


### PR DESCRIPTION
## 관련 이슈
<!--
이슈 번호 #000 작성  
ex) close #1 
--> 
- close #247 

## 내용
<!--
로직 설명  
필요시 스크린샷 첨부
--> 
- 블로그가 있는 유저 회원 가입시 , DB 업데이트를 위한 함수를 구현했습니다. 하지만 현재 실행하지는 않습니다.
  - 함수 구현을 통해 확인을 했고 Deploy까지 완료했습니다. 하지만 시간이 10초 넘게 걸리는 등 평균적으로 너무 긴 로딩 시간을 유저에게 보여줍니다. 이에 따라 스케줄러에 따른 DB 업데이트를 기다리려고 합니다.
- 회원 가입 버튼 누르면 키보드가 사라지도록 했습니다.
- textField + Combine publisher가 2종류 입니다.
  - `textChangedPublisher` :  글자가 바뀔 때마다 publish
  -  `textEditingEndPublisher` : textField에서 focus out 되면 publish

## 결과 이미지 

![스크린샷 2023-02-04 오후 8 26 29](https://user-images.githubusercontent.com/71776532/216765535-dd81b2af-e8ff-4b40-afff-4c4e43418623.png)

너무 오랜 시간이 걸려 유저 UX를 해침

## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
