### PR TITLE
fix: Indicator 위치 수정

### DIFF
--- a/burstcamp/burstcamp/Presentation/Tab/MyPage/MyPage/ViewController/MyPageViewController.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/MyPage/MyPage/ViewController/MyPageViewController.swift
@@ -176,11 +176,12 @@ final class MyPageViewController: AppleAuthViewController {
             self?.updateActivityOverlayDescriptionLabel("유저 정보 삭제 중")
             do {
                 try await viewModel.withdrawalWithApple(idTokenString: idTokenString, nonce: nonce)
+                self?.hideAnimatedActivityIndicatorView()
                 self?.moveToAuthFlow()
             } catch {
+                self?.hideAnimatedActivityIndicatorView()
                 self?.showAlert(message: "애플 로그인에 실패했습니다. \(error.localizedDescription)")
             }
-            self?.hideAnimatedActivityIndicatorView()
         }
     }
 }


### PR DESCRIPTION
## 관련 이슈
<!--
이슈 번호 #000 작성  
ex) close #1 
--> 

## 내용
<!--
로직 설명  
필요시 스크린샷 첨부
--> 
- 애플 회원 탈퇴시 indicator가 사라지지 않는 에러를 수정했습니다.
  - 기존에 coordinator - `moveToAuthFlow`로 이동하고 나서 hideIndicator를 호출해 indicator가 사라지지 않았습니다.
  - 함수 호출 위치를 수정했습니다.
## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
