### PR TITLE
[fix] 탈퇴시 scrapCount 조정 & removeUserListener

### DIFF
--- a/burstcamp/burstcamp/Domain/UseCase/Tab/MyPage/DefaultMyPageUseCase.swift
+++ b/burstcamp/burstcamp/Domain/UseCase/Tab/MyPage/DefaultMyPageUseCase.swift
@@ -20,7 +20,9 @@ final class DefaultMyPageUseCase: MyPageUseCase {
     }
 
     func withdrawalWithGithub(code: String) async throws {
+        UserManager.shared.removeUserListener()
         let user = UserManager.shared.user
+
         let isSuccess = try await loginRepository.withdrawalWithGithub(code: code, userUUID: user.userUUID)
         try await deleteProfileImage(userUUID: user.userUUID, profileImageURL: user.profileImageURL)
         deleteLocalUser()
@@ -28,7 +30,9 @@ final class DefaultMyPageUseCase: MyPageUseCase {
     }
 
     func withdrawalWithApple(idTokenString: String, nonce: String) async throws {
+        UserManager.shared.removeUserListener()
         let userUUID = UserManager.shared.user.userUUID
+
         let isSuccess = try await loginRepository.withdrawalWithApple(
             idTokenString: idTokenString,
             nonce: nonce,
@@ -72,7 +76,6 @@ final class DefaultMyPageUseCase: MyPageUseCase {
 
     private func deleteLocalUser() {
         KeyChainManager.deleteUser()
-        UserManager.shared.removeUserListener()
         UserManager.shared.deleteUserInfo()
     }
 }


### PR DESCRIPTION
## 관련 이슈
<!--
이슈 번호 #000 작성  
ex) close #1 
--> 

## 내용
<!--
로직 설명  
필요시 스크린샷 첨부
--> 
- 기존에 탈퇴시 scrapCount - 1이 안되던 걸 수정했습니다.
- remove UserListener 이후에 서버의 UserData를 삭제하도록 순서를 조정했습니다.
  - 기존에 UserData를 삭제하고 remove UserListener를 진행하느라, error Alert이 떴습니다. 이를 수정하기 위해 위치를 조정했습니다.

## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
