### PR TITLE
Fix/scrap page refresh

### DIFF
--- a/burstcamp/burstcamp/Presentation/Tab/ScrapPage/ViewController/ScrapPageViewController.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/ScrapPage/ViewController/ScrapPageViewController.swift
@@ -162,6 +162,7 @@ final class ScrapPageViewController: UIViewController {
                     self.isFetching = true
                     return true
                 } else {
+                    self.scrapPageView.endCollectionViewRefreshing()
                     return false
                 }
             }
@@ -183,7 +184,7 @@ final class ScrapPageViewController: UIViewController {
 
     private func handleRecentScrapFeedList(_ scrapFeedList: [Feed]?) {
         scrapPageView.endCollectionViewRefreshing()
-        
+
         guard let scrapFeedList = scrapFeedList else {
             showAlert(message: "피드 데이터를 가져오는데 에러가 발생했어요")
             return

--- a/burstcamp/burstcamp/Presentation/Tab/ScrapPage/ViewController/ScrapPageViewController.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/ScrapPage/ViewController/ScrapPageViewController.swift
@@ -182,6 +182,8 @@ final class ScrapPageViewController: UIViewController {
     }
 
     private func handleRecentScrapFeedList(_ scrapFeedList: [Feed]?) {
+        scrapPageView.endCollectionViewRefreshing()
+        
         guard let scrapFeedList = scrapFeedList else {
             showAlert(message: "피드 데이터를 가져오는데 에러가 발생했어요")
             return
@@ -192,7 +194,6 @@ final class ScrapPageViewController: UIViewController {
         }
 
         refreshScrapFeedList(scrapFeedList: scrapFeedList)
-        scrapPageView.endCollectionViewRefreshing()
         isFetching = false
     }
 

--- a/burstcamp/burstcamp/Presentation/Tab/ScrapPage/ViewController/ScrapPageViewController.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/ScrapPage/ViewController/ScrapPageViewController.swift
@@ -31,7 +31,7 @@ final class ScrapPageViewController: UIViewController {
 
     private var isFetching: Bool = false
     private var isLastFetch: Bool = false
-
+    private let paginateCount = 10
     // MARK: - Initializer
 
     init(viewModel: ScrapPageViewModel) {
@@ -171,7 +171,7 @@ final class ScrapPageViewController: UIViewController {
     private func createPaginationPublisher() -> AnyPublisher<Void, Never> {
         return paginationPublisher
             .filter { _ in
-                if !self.isFetching && !self.isLastFetch {
+                if !self.isFetching && !self.isLastFetch && self.viewModel.getCount() >= self.paginateCount {
                     self.isFetching = true
                     return true
                 } else {

--- a/burstcamp/burstcamp/Presentation/Tab/ScrapPage/ViewModel/ScrapPageViewModel.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/ScrapPage/ViewModel/ScrapPageViewModel.swift
@@ -105,4 +105,8 @@ extension ScrapPageViewModel {
         }
         return scrapFeedList
     }
+
+    func getCount() -> Int {
+        return scrapFeedList.count
+    }
 }


### PR DESCRIPTION
## 관련 이슈
<!--
이슈 번호 #000 작성  
ex) close #1 
--> 
- close #344 

## 내용
<!--
로직 설명  
필요시 스크린샷 첨부
--> 
- 실제 기기에서 refresh가 안 멈추는 에러가 있습니다.
  - 시뮬레이터에서는 괜찮은데 TestFlight으로 받으면 뜨네요
  - Refresing 호출과 pagination 호출이 겹치면서 발생하는 에러로 판단됩니다.
  - 기존에는 스크랩 피드 수에 상관없이 페이지네이션 Publisher가 호출됐는데, 이제는 10개이상부터 호출됩니다. 페이지네이션 단위가 10개 이고 지금 colletionView에 10개 보다 적다는 것은 스크랩한 피드가 10 개 이하이므로 추가 요청이 필요없기 때문입니다.
 
## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
