### PR TITLE
[Feature] 신고하기 & 차단하기 추가

### DIFF
--- a/burstcamp/burstcamp.xcodeproj/project.pbxproj
+++ b/burstcamp/burstcamp.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		1458C6952928FB1B00E00B80 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1458C6942928FB1B00E00B80 /* HomeView.swift */; };
 		1459C3BA292910B300FA885D /* RecommendFeedCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1459C3B9292910B300FA885D /* RecommendFeedCell.swift */; };
 		1459C3BC2929150200FA885D /* FeedCellType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1459C3BB2929150200FA885D /* FeedCellType.swift */; };
+		1473D8542993209C00408C9B /* ActionSheetEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1473D8532993209C00408C9B /* ActionSheetEvent.swift */; };
 		14755A4C2973FA8C0036B71D /* LoginRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14755A4B2973FA8C0036B71D /* LoginRepository.swift */; };
 		14755A4E2973FAA50036B71D /* DefaultLoginRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14755A4D2973FAA50036B71D /* DefaultLoginRepository.swift */; };
 		14882664298CD86800DB6D3B /* GithubLoginDatasource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14882663298CD86800DB6D3B /* GithubLoginDatasource.swift */; };
@@ -291,6 +292,7 @@
 		1458C6942928FB1B00E00B80 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		1459C3B9292910B300FA885D /* RecommendFeedCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecommendFeedCell.swift; sourceTree = "<group>"; };
 		1459C3BB2929150200FA885D /* FeedCellType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedCellType.swift; sourceTree = "<group>"; };
+		1473D8532993209C00408C9B /* ActionSheetEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionSheetEvent.swift; sourceTree = "<group>"; };
 		14755A4B2973FA8C0036B71D /* LoginRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginRepository.swift; sourceTree = "<group>"; };
 		14755A4D2973FAA50036B71D /* DefaultLoginRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultLoginRepository.swift; sourceTree = "<group>"; };
 		14882663298CD86800DB6D3B /* GithubLoginDatasource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GithubLoginDatasource.swift; sourceTree = "<group>"; };
@@ -1653,6 +1655,7 @@
 			isa = PBXGroup;
 			children = (
 				B5DAD674292E4C6800C4A126 /* FeedDetailViewModel.swift */,
+				1473D8532993209C00408C9B /* ActionSheetEvent.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -2003,6 +2006,7 @@
 				141344D7292F801100187B86 /* TimeInterval+.swift in Sources */,
 				141299542976376500159C02 /* UserManagerError.swift in Sources */,
 				D8494D4A2927CBD4008157F1 /* DefaultButton.swift in Sources */,
+				1473D8542993209C00408C9B /* ActionSheetEvent.swift in Sources */,
 				D89AE4F32935AFE100446AB3 /* Notification+.swift in Sources */,
 				1458C6952928FB1B00E00B80 /* HomeView.swift in Sources */,
 				B50A27FE29279F5D00DF3E1F /* Coordinator.swift in Sources */,

--- a/burstcamp/burstcamp/Data/Repositories/FeedRepository/DefaultFeedRepository.swift
+++ b/burstcamp/burstcamp/Data/Repositories/FeedRepository/DefaultFeedRepository.swift
@@ -105,4 +105,12 @@ final class DefaultFeedRepository: FeedRepository {
     func createMockUpRecommendFeedList(count: Int) -> [Feed] {
         return feedMockUpDataSource.createMockUpRecommendFeedList(count: count)
     }
+
+    func blockFeed(_ feed: Feed, userUUID: String, wasScraped: Bool) async throws {
+        try await bcFirestoreService.blockFeed(feed.toFeedAPIModel(), with: userUUID, wasScraped: true)
+    }
+
+    func reportFeed(_ feed: Feed, userUUID: String) async throws {
+        try await bcFirestoreService.reportFeed(feed.feedUUID, with: userUUID)
+    }
 }

--- a/burstcamp/burstcamp/Data/Repositories/FeedRepository/MockUpFeedRepository.swift
+++ b/burstcamp/burstcamp/Data/Repositories/FeedRepository/MockUpFeedRepository.swift
@@ -56,6 +56,14 @@ extension MockUpFeedRepository {
     func createMockUpRecommendFeedList(count: Int) -> [Feed] {
         return []
     }
+
+    func reportFeed(_ feed: Feed, userUUID: String) async throws {
+        throw MockUpFeedRepositoryError.noImplementation
+    }
+
+    func blockFeed(_ feed: Feed, userUUID: String, wasScraped: Bool) async throws {
+        throw MockUpFeedRepositoryError.noImplementation
+    }
 }
 
 struct MockUpFeedData {

--- a/burstcamp/burstcamp/Data/Repositories/UserRepository/DefaultUserRepository.swift
+++ b/burstcamp/burstcamp/Data/Repositories/UserRepository/DefaultUserRepository.swift
@@ -68,6 +68,7 @@ final class DefaultUserRepository: UserRepository {
             blogURL: user.blogURL,
             blogTitle: user.blogTitle,
             scrapFeedUUIDs: user.scrapFeedUUIDs,
+            reportFeedUUIDs: user.reportFeedUUIDs,
             signupDate: user.signupDate,
             updateDate: user.updateDate,
             isPushOn: user.isPushOn

--- a/burstcamp/burstcamp/Domain/Interfaces/FeedRepository/FeedRepository.swift
+++ b/burstcamp/burstcamp/Domain/Interfaces/FeedRepository/FeedRepository.swift
@@ -20,4 +20,7 @@ protocol FeedRepository {
     func unScrapFeed(_ feed: Feed, userUUID: String) async throws -> Feed
 
     func createMockUpRecommendFeedList(count: Int) -> [Feed]
+
+    func blockFeed(_ feed: Feed, userUUID: String, wasScraped: Bool) async throws
+    func reportFeed(_ feed: Feed, userUUID: String) async throws
 }

--- a/burstcamp/burstcamp/Domain/Model/User/User.swift
+++ b/burstcamp/burstcamp/Domain/Model/User/User.swift
@@ -19,6 +19,7 @@ struct User: Codable, Equatable {
     private(set) var blogURL: String
     let blogTitle: String
     private(set) var scrapFeedUUIDs: [String]
+    private(set) var reportFeedUUIDs: [String]
     let signupDate: Date
     private(set) var updateDate: Date
     let isPushOn: Bool
@@ -42,6 +43,7 @@ struct User: Codable, Equatable {
             blogURL: self.blogURL,
             blogTitle: self.blogTitle,
             scrapFeedUUIDs: self.scrapFeedUUIDs,
+            reportFeedUUIDs: self.reportFeedUUIDs,
             signupDate: self.signupDate,
             updateDate: self.updateDate,
             isPushOn: self.isPushOn
@@ -59,6 +61,7 @@ struct User: Codable, Equatable {
             blogURL: self.blogURL,
             blogTitle: self.blogTitle,
             scrapFeedUUIDs: self.scrapFeedUUIDs,
+            reportFeedUUIDs: self.reportFeedUUIDs,
             signupDate: self.signupDate,
             updateDate: Date(),
             isPushOn: self.isPushOn
@@ -78,6 +81,7 @@ extension User {
         self.blogURL = dictionary["blogURL"] as? String ?? ""
         self.blogTitle = dictionary["blogTitle"] as? String ?? ""
         self.scrapFeedUUIDs = dictionary["scrapFeedUUIDs"] as? [String] ?? []
+        self.reportFeedUUIDs = dictionary["reportFeedUUIDs"] as? [String] ?? []
         self.signupDate = dictionary["signupDate"] as? Date ?? Date()
         self.updateDate = dictionary["updateDate"] as? Date ?? Date(timeIntervalSince1970: 0)
         self.isPushOn = dictionary["isPushOn"] as? Bool ?? false
@@ -103,6 +107,7 @@ extension User {
         self.blogURL = signUpUser.getBlogURL()
         self.blogTitle = blogTitle
         self.scrapFeedUUIDs = []
+        self.reportFeedUUIDs = []
         self.signupDate = Date()
         self.updateDate = Date(timeIntervalSince1970: 0)
         self.isPushOn = false
@@ -120,6 +125,7 @@ extension User {
         self.blogURL = userAPIModel.blogURL
         self.blogTitle = userAPIModel.blogTitle
         self.scrapFeedUUIDs = userAPIModel.scrapFeedUUIDs
+        self.reportFeedUUIDs = userAPIModel.reportFeedUUIDs
         self.signupDate = userAPIModel.signupDate
         self.updateDate = userAPIModel.updateDate
         self.isPushOn = userAPIModel.isPushOn
@@ -140,6 +146,7 @@ extension User {
         self.blogURL = ""
         self.blogTitle = ""
         self.scrapFeedUUIDs = []
+        self.reportFeedUUIDs = []
         self.signupDate = Date()
         self.updateDate = Date(timeIntervalSince1970: 0)
         self.isPushOn = false

--- a/burstcamp/burstcamp/Domain/UseCase/Tab/Detail/DefaultFeedDetailUseCase.swift
+++ b/burstcamp/burstcamp/Domain/UseCase/Tab/Detail/DefaultFeedDetailUseCase.swift
@@ -24,4 +24,19 @@ final class DefaultFeedDetailUseCase: FeedDetailUseCase {
         ? try await feedRepository.unScrapFeed(feed, userUUID: userUUID)
         : try await feedRepository.scrapFeed(feed, userUUID: userUUID)
     }
+
+    func blockFeed(_ feed: Feed) async throws {
+        let user = UserManager.shared.user
+        let wasScraped = user.scrapFeedUUIDs.contains(feed.feedUUID)
+
+        try await feedRepository.blockFeed(feed, userUUID: user.userUUID, wasScraped: wasScraped)
+    }
+
+    func reportFeed(_ feed: Feed) async throws {
+        let user = UserManager.shared.user
+        let wasScraped = user.scrapFeedUUIDs.contains(feed.feedUUID)
+
+        try await feedRepository.reportFeed(feed, userUUID: user.userUUID)
+        try await feedRepository.blockFeed(feed, userUUID: user.userUUID, wasScraped: wasScraped)
+    }
 }

--- a/burstcamp/burstcamp/Domain/UseCase/Tab/Detail/FeedDetailUseCase.swift
+++ b/burstcamp/burstcamp/Domain/UseCase/Tab/Detail/FeedDetailUseCase.swift
@@ -11,4 +11,7 @@ protocol FeedDetailUseCase {
     func fetchFeed(by feedUUID: String) async throws -> Feed
 
     func scrapFeed(_ feed: Feed, userUUID: String) async throws -> Feed
+
+    func blockFeed(_ feed: Feed) async throws
+    func reportFeed(_ feed: Feed) async throws
 }

--- a/burstcamp/burstcamp/Domain/UseCase/Tab/Home/DefaultHomeUseCase.swift
+++ b/burstcamp/burstcamp/Domain/UseCase/Tab/Home/DefaultHomeUseCase.swift
@@ -13,33 +13,32 @@ final class DefaultHomeUseCase: HomeUseCase {
 
     private let feedRepository: FeedRepository
     private let userRepository: UserRepository
+    private var scarpFeedUUID: [String: String]
     private var reportFeedUUID: [String: String]
 
     init(feedRepository: FeedRepository, userRepository: UserRepository) {
         self.feedRepository = feedRepository
         self.userRepository = userRepository
+        self.scarpFeedUUID = [:]
         self.reportFeedUUID = [:]
     }
 
     func fetchRecentHomeFeedList() async throws -> HomeFeedList {
-        let userScrapFeedUUIDs = UserManager.shared.user.scrapFeedUUIDs
         let homeFeedList = try await feedRepository.fetchRecentHomeFeedList()
-        let normalFeed = homeFeedList.normalFeed.map({ feed in
-            return userScrapFeedUUIDs.contains(feed.feedUUID) ? feed.setIsScraped(true) : feed
-        })
 
-        let filterReportFeed = filterReportFeed(normalFeed)
+        let filterReportFeed = filterReportFeed(homeFeedList.normalFeed)
+        let filterScarpFeed = filterScrapFeed(filterReportFeed)
 
         let recommendFeed = addBurstcampNoticeIfNeed(recommendFeedList: homeFeedList.recommendFeed)
         let tripleRecommendFeed = recommendFeedForCarousel(recommendFeed)
-        return HomeFeedList(recommendFeed: tripleRecommendFeed, normalFeed: filterReportFeed)
+        return HomeFeedList(recommendFeed: tripleRecommendFeed, normalFeed: filterScarpFeed)
     }
 
     func fetchMoreNormalFeed() async throws -> [Feed] {
-        let userScrapFeedUUIDs = UserManager.shared.user.scrapFeedUUIDs
-        return try await feedRepository.fetchMoreNormalFeed().map { feed in
-            return userScrapFeedUUIDs.contains(feed.feedUUID) ? feed.setIsScraped(true) : feed
-        }
+        let normalFeed = try await feedRepository.fetchMoreNormalFeed()
+        let filterReportFeed = filterReportFeed(normalFeed)
+        let filterScarpFeed = filterScrapFeed(filterReportFeed)
+        return filterScarpFeed
     }
 
     func scrapFeed(_ feed: Feed, userUUID: String) async throws -> Feed {
@@ -79,6 +78,21 @@ final class DefaultHomeUseCase: HomeUseCase {
     private func arrayToDictionary(reportFeedList: [String]) -> [String: String] {
         return Dictionary(uniqueKeysWithValues: reportFeedList.map { ($0, $0)})
     }
+
+    // MARK: 스크랩 피드 필터링
+
+    private func updateScrapFeedUUID() {
+        self.scarpFeedUUID = arrayToDictionary(reportFeedList: UserManager.shared.user.scrapFeedUUIDs)
+    }
+
+    private func filterScrapFeed(_ feedList: [Feed]) -> [Feed] {
+        updateScrapFeedUUID()
+        return feedList.map { feed in
+            return scarpFeedUUID[feed.feedUUID] != nil ? feed.setIsScraped(true) : feed
+        }
+    }
+
+    // MARK: - 차단 피드 필터링
 
     private func updateReportFeedUUID() {
         self.reportFeedUUID = arrayToDictionary(reportFeedList: UserManager.shared.user.reportFeedUUIDs)

--- a/burstcamp/burstcamp/Presentation/Coordinator/Base/ContainFeedDetailCoordinator.swift
+++ b/burstcamp/burstcamp/Presentation/Coordinator/Base/ContainFeedDetailCoordinator.swift
@@ -24,6 +24,8 @@ extension ContainFeedDetailCoordinator {
                 switch event {
                 case .moveToBlogSafari(let url):
                     self?.moveToBlogSafari(url: url)
+                case .moveToPreviousScreen:
+                    self?.popFeedDetailViewController(feedDetailViewController)
                 }
             }
             .store(in: &cancelBag)
@@ -35,12 +37,18 @@ extension ContainFeedDetailCoordinator {
                 switch event {
                 case .moveToBlogSafari(let url):
                     self?.moveToBlogSafari(url: url)
+                case .moveToPreviousScreen:
+                    self?.popFeedDetailViewController(feedDetailViewController)
                 }
             }
             .store(in: &cancelBag)
 
         let updateFeedPublisher = feedDetailViewController.getUpdateFeedPublisher()
-        parentViewController.configure(scrapUpdatePublisher: updateFeedPublisher)
+        let deleteFeedPublisher = feedDetailViewController.getDeleteFeedPublisher()
+        parentViewController.configure(
+            scrapUpdatePublisher: updateFeedPublisher,
+            deletePublisher: deleteFeedPublisher
+        )
     }
 
     func prepareFeedDetailViewController(feed: Feed) -> FeedDetailViewController {
@@ -57,5 +65,13 @@ extension ContainFeedDetailCoordinator {
             feedDetailViewModel: feedDetailViewModel
         )
         return feedDetailViewController
+    }
+
+    func popFeedDetailViewController(
+        _ feedDetailViewController: FeedDetailViewController
+    ) {
+        DispatchQueue.main.async {
+            self.navigationController.popViewController(animated: true)
+        }
     }
 }

--- a/burstcamp/burstcamp/Presentation/Coordinator/Base/ContainFeedDetailCoordinator.swift
+++ b/burstcamp/burstcamp/Presentation/Coordinator/Base/ContainFeedDetailCoordinator.swift
@@ -25,7 +25,7 @@ extension ContainFeedDetailCoordinator {
                 case .moveToBlogSafari(let url):
                     self?.moveToBlogSafari(url: url)
                 case .moveToPreviousScreen:
-                    self?.popFeedDetailViewController(feedDetailViewController)
+                    self?.popFeedDetailViewController()
                 }
             }
             .store(in: &cancelBag)
@@ -38,7 +38,7 @@ extension ContainFeedDetailCoordinator {
                 case .moveToBlogSafari(let url):
                     self?.moveToBlogSafari(url: url)
                 case .moveToPreviousScreen:
-                    self?.popFeedDetailViewController(feedDetailViewController)
+                    self?.popFeedDetailViewController()
                 }
             }
             .store(in: &cancelBag)
@@ -67,11 +67,9 @@ extension ContainFeedDetailCoordinator {
         return feedDetailViewController
     }
 
-    func popFeedDetailViewController(
-        _ feedDetailViewController: FeedDetailViewController
-    ) {
-        DispatchQueue.main.async {
-            self.navigationController.popViewController(animated: true)
+    func popFeedDetailViewController() {
+        DispatchQueue.main.async { [weak self] in
+            self?.navigationController.popViewController(animated: true)
         }
     }
 }

--- a/burstcamp/burstcamp/Presentation/Coordinator/Base/CoordinatorEvent.swift
+++ b/burstcamp/burstcamp/Presentation/Coordinator/Base/CoordinatorEvent.swift
@@ -45,4 +45,5 @@ enum MyPageCoordinatorEvent {
 
 enum FeedDetailCoordinatorEvent {
     case moveToBlogSafari(url: URL)
+    case moveToPreviousScreen
 }

--- a/burstcamp/burstcamp/Presentation/Tab/Detail/ViewController/FeedDetailViewController.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/Detail/ViewController/FeedDetailViewController.swift
@@ -20,7 +20,7 @@ final class FeedDetailViewController: UIViewController {
     }
 
     private lazy var barButtonStackView = UIStackView().then {
-        $0.addArrangedSubViews([scrapButton, shareButton])
+        $0.addArrangedSubViews([scrapButton, shareButton, ellipsisButton])
         $0.spacing = Constant.space24.cgFloat
     }
     private lazy var barButtonStackViewItem = UIBarButtonItem(customView: barButtonStackView)
@@ -30,15 +30,19 @@ final class FeedDetailViewController: UIViewController {
         onColor: .main,
         offColor: .systemGray5
     )
-    private lazy var scrapBarButtonItem = UIBarButtonItem(customView: scrapButton)
-
     private let shareButton = UIButton().then {
         $0.setImage(
             UIImage(systemName: "square.and.arrow.up"),
             for: .normal
         )
     }
-    private lazy var shareBarButtonItem = UIBarButtonItem(customView: shareButton)
+
+    private let ellipsisButton = UIButton().then {
+        $0.setImage(
+            UIImage(systemName: "ellipsis"),
+            for: .normal
+        )
+    }
 
     private let feedDetailViewModel: FeedDetailViewModel
 
@@ -82,6 +86,12 @@ final class FeedDetailViewController: UIViewController {
             .map { [weak self] _ in
                 self?.scrapButton.isEnabled = false
                 return
+            }
+            .eraseToAnyPublisher()
+
+        let ellipsisDidTap = ellipsisButton.tapPublisher
+            .map { _ in
+                self.showActionSheet()
             }
             .eraseToAnyPublisher()
 
@@ -165,4 +175,33 @@ extension FeedDetailViewController {
     func getUpdateFeedPublisher() -> AnyPublisher<Feed, Never> {
         return updateFeedPublisher.eraseToAnyPublisher()
     }
+}
+
+extension FeedDetailViewController {
+    func showActionSheet() {
+        let actionSheetController: UIAlertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+        let firstAction: UIAlertAction = UIAlertAction(title: "신고하기", style: .default) { action in
+            
+        }
+
+        let secondAction: UIAlertAction = UIAlertAction(title: "차단하기", style: .default) { action in
+            
+        }
+
+        let cancelAction: UIAlertAction = UIAlertAction(title: "취소", style: .cancel)
+
+        // add actions
+        actionSheetController.addAction(firstAction)
+        actionSheetController.addAction(secondAction)
+        actionSheetController.addAction(cancelAction)
+
+        DispatchQueue.main.async {
+            self.present(actionSheetController, animated: true)
+        }
+    }
+}
+
+enum ActionSheetEvent {
+    case report
+    case block
 }

--- a/burstcamp/burstcamp/Presentation/Tab/Detail/ViewController/FeedDetailViewController.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/Detail/ViewController/FeedDetailViewController.swift
@@ -92,8 +92,8 @@ final class FeedDetailViewController: UIViewController {
             .eraseToAnyPublisher()
 
         ellipsisButton.tapPublisher
-            .sink { _ in
-                self.showActionSheet()
+            .sink { [weak self] _ in
+                self?.showActionSheet()
             }
             .store(in: &cancelBag)
 

--- a/burstcamp/burstcamp/Presentation/Tab/Detail/ViewModel/ActionSheetEvent.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/Detail/ViewModel/ActionSheetEvent.swift
@@ -1,0 +1,13 @@
+//
+//  ActionSheetEvent.swift
+//  burstcamp
+//
+//  Created by youtak on 2023/02/08.
+//
+
+import Foundation
+
+enum ActionSheetEvent {
+    case report
+    case block
+}

--- a/burstcamp/burstcamp/Presentation/Tab/Detail/ViewModel/FeedDetailViewModel.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/Detail/ViewModel/FeedDetailViewModel.swift
@@ -33,6 +33,7 @@ final class FeedDetailViewModel {
         let blogButtonDidTap: AnyPublisher<Void, Never>
         let shareButtonDidTap: AnyPublisher<Void, Never>
         let scrapButtonDidTap: AnyPublisher<Void, Never>
+        let actionSheetEvent: AnyPublisher<ActionSheetEvent, Never>
     }
 
     struct Output {
@@ -40,6 +41,7 @@ final class FeedDetailViewModel {
         let openBlog: AnyPublisher<URL, Never>
         let openActivityView: AnyPublisher<String, Never>
         let scrapUpdate: AnyPublisher<Feed?, Error>
+        let actionSheetResult: AnyPublisher<ActionSheetEvent, Never>
     }
 
     func transform(input: Input) -> Output {
@@ -63,11 +65,25 @@ final class FeedDetailViewModel {
             }
             .eraseToAnyPublisher()
 
+        let actionSheetResult = input.actionSheetEvent
+            .map { event in
+                switch event {
+                case .report:
+                    print("report")
+                    return ActionSheetEvent.report
+                case .block:
+                    print("block")
+                    return ActionSheetEvent.block
+                }
+            }
+            .eraseToAnyPublisher()
+
         return Output(
             feedDidUpdate: feedPublisher.eraseToAnyPublisher(),
             openBlog: openBlog,
             openActivityView: openActivityView,
-            scrapUpdate: scrapUpdate
+            scrapUpdate: scrapUpdate,
+            actionSheetResult: actionSheetResult
         )
     }
 

--- a/burstcamp/burstcamp/Presentation/Tab/Home/ViewController/HomeViewController.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/Home/ViewController/HomeViewController.swift
@@ -138,6 +138,7 @@ extension HomeViewController {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] feed in
                 self?.deleteSnapshot(feed: feed)
+                self?.showAlert(title: "신고 및 차단 완료", message: "앞으로 게시물이 보이지 않습니다. \n신고된 게시물은 24시간 안에 처리됩니다.")
             }
             .store(in: &cancelBag)
     }

--- a/burstcamp/burstcamp/Presentation/Tab/Home/ViewController/HomeViewController.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/Home/ViewController/HomeViewController.swift
@@ -395,7 +395,12 @@ extension HomeViewController {
         }
     }
 
-    private func deleteSnapshot(feed: Feed) {
+    private func deleteSnapshot(feed: Feed?) {
+        guard let feed = feed else {
+            debugPrint("삭제 feed가 nil")
+            return
+        }
+
         collectionViewSnapShot.deleteItems([DiffableFeed.normal(feed)])
         dataSource.apply(collectionViewSnapShot, animatingDifferences: false)
     }

--- a/burstcamp/burstcamp/Presentation/Tab/Home/ViewModel/HomeViewModel.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/Home/ViewModel/HomeViewModel.swift
@@ -38,7 +38,7 @@ final class HomeViewModel {
     struct Output {
         let recentHomeFeedList: AnyPublisher<HomeFeedList?, Error>
         let paginateNormalFeedList: AnyPublisher<[Feed]?, Error>
-        let deleteFeed: AnyPublisher<Feed, Never>
+        let deleteFeed: AnyPublisher<Feed?, Never>
     }
 
     struct CellOutput {
@@ -60,8 +60,8 @@ final class HomeViewModel {
             .eraseToAnyPublisher()
 
         let deleteFeed = input.feedDeletePublisher
-            .map { feed in
-                self.deleteFeedFromList(feed)
+            .map { [weak self] feed in
+                self?.deleteFeedFromList(feed)
             }
             .eraseToAnyPublisher()
 

--- a/burstcamp/burstcamp/Presentation/Tab/Home/ViewModel/HomeViewModel.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/Home/ViewModel/HomeViewModel.swift
@@ -28,6 +28,7 @@ final class HomeViewModel {
         let viewDidLoad: AnyPublisher<Void, Never>
         let viewDidRefresh: AnyPublisher<Void, Never>
         let pagination: AnyPublisher<Void, Never>
+        let feedDeletePublisher: AnyPublisher<Feed, Never>
     }
 
     struct CellInput {
@@ -37,6 +38,7 @@ final class HomeViewModel {
     struct Output {
         let recentHomeFeedList: AnyPublisher<HomeFeedList?, Error>
         let paginateNormalFeedList: AnyPublisher<[Feed]?, Error>
+        let deleteFeed: AnyPublisher<Feed, Never>
     }
 
     struct CellOutput {
@@ -57,9 +59,16 @@ final class HomeViewModel {
             }
             .eraseToAnyPublisher()
 
+        let deleteFeed = input.feedDeletePublisher
+            .map { feed in
+                self.deleteFeedFromList(feed)
+            }
+            .eraseToAnyPublisher()
+
         return Output(
             recentHomeFeedList: recentHomeFeedList,
-            paginateNormalFeedList: paginateNormalFeedList
+            paginateNormalFeedList: paginateNormalFeedList,
+            deleteFeed: deleteFeed
         )
     }
 
@@ -108,6 +117,11 @@ final class HomeViewModel {
         } else {
             throw HomeViewModelError.feedIndex
         }
+    }
+
+    private func deleteFeedFromList(_ feed: Feed) -> Feed {
+        normalFeedList = normalFeedList.filter { $0 != feed }
+        return feed
     }
 }
 

--- a/burstcamp/burstcamp/Presentation/Tab/ScrapPage/ViewController/ScrapPageViewController.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/ScrapPage/ViewController/ScrapPageViewController.swift
@@ -305,7 +305,10 @@ extension ScrapPageViewController {
 }
 
 extension ScrapPageViewController: ContainFeedDetailViewController {
-    func configure(scrapUpdatePublisher: AnyPublisher<Feed, Never>) {
+    func configure(
+        scrapUpdatePublisher: AnyPublisher<Feed, Never>,
+        deletePublisher: AnyPublisher<Feed, Never>
+    ) {
         scrapUpdatePublisher
             .sink { [weak self] feed in
                 guard let feedList = self?.viewModel.updateScrapFeed(feed) else {

--- a/burstcamp/burstcamp/Presentation/Tab/ScrapPage/ViewModel/ScrapPageViewModel.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/ScrapPage/ViewModel/ScrapPageViewModel.swift
@@ -29,6 +29,7 @@ final class ScrapPageViewModel {
         let viewDidLoad: AnyPublisher<Void, Never>
         let viewDidRefresh: AnyPublisher<Void, Never>
         let pagination: AnyPublisher<Void, Never>
+        let feedDeletePublisher: AnyPublisher<Feed, Never>
     }
 
     struct CellInput {
@@ -38,6 +39,7 @@ final class ScrapPageViewModel {
     struct Output {
         let recentScrapFeed: AnyPublisher<[Feed]?, Error>
         let paginateScrapFeed: AnyPublisher<[Feed]?, Error>
+        let deleteFeed: AnyPublisher<Feed?, Never>
     }
 
     struct CellOutput {
@@ -59,9 +61,16 @@ final class ScrapPageViewModel {
             }
             .eraseToAnyPublisher()
 
+        let deleteFeed = input.feedDeletePublisher
+            .map { [weak self] feed in
+                self?.deleteFeedFromList(feed)
+            }
+            .eraseToAnyPublisher()
+
         return Output(
             recentScrapFeed: recentScrapFeedPublisher,
-            paginateScrapFeed: paginationPublisher
+            paginateScrapFeed: paginationPublisher,
+            deleteFeed: deleteFeed
         )
     }
 
@@ -95,6 +104,11 @@ final class ScrapPageViewModel {
         let scrapFeed = try await scrapPageUseCase.fetchMoreScrapFeed()
         scrapFeedList.append(contentsOf: scrapFeed)
         return scrapFeed
+    }
+
+    private func deleteFeedFromList(_ feed: Feed) -> Feed {
+        scrapFeedList = scrapFeedList.filter { $0 != feed }
+        return feed
     }
 }
 

--- a/burstcamp/burstcamp/Util/Protocol/ContainFeedDetailViewController.swift
+++ b/burstcamp/burstcamp/Util/Protocol/ContainFeedDetailViewController.swift
@@ -9,5 +9,8 @@ import Combine
 import Foundation
 
 protocol ContainFeedDetailViewController {
-    func configure(scrapUpdatePublisher: AnyPublisher<Feed, Never>)
+    func configure(
+        scrapUpdatePublisher: AnyPublisher<Feed, Never>,
+        deletePublisher: AnyPublisher<Feed, Never>
+    )
 }

--- a/modules/BCFirebase/BCFirebase/Firestore/FirestoreCollection.swift
+++ b/modules/BCFirebase/BCFirebase/Firestore/FirestoreCollection.swift
@@ -17,8 +17,10 @@ enum FirestoreCollection {
     case scrapFeeds(userUUID: String)
     case admin
     case fcmToken
+    case reportFeed
 
     static let scrapFeedUUIDs = "scrapFeedUUIDs"
+    static let reportFeedUUIDs = "reportFeedUUIDs"
 }
 
 extension FirestoreCollection {
@@ -32,6 +34,7 @@ extension FirestoreCollection {
         case .scrapFeeds(let userUUID): return "user/\(userUUID)/scrapFeeds"
         case .admin: return "admin"
         case .fcmToken: return "fcmToken"
+        case .reportFeed: return "reportFeed"
         }
     }
 }

--- a/modules/BCFirebase/BCFirebase/Model/UserAPIModel.swift
+++ b/modules/BCFirebase/BCFirebase/Model/UserAPIModel.swift
@@ -19,6 +19,7 @@ public struct UserAPIModel {
     public let blogURL: String
     public let blogTitle: String
     public var scrapFeedUUIDs: [String]
+    public var reportFeedUUIDs: [String]
     public let signupDate: Date
     public let updateDate: Date
     public let isPushOn: Bool
@@ -32,6 +33,7 @@ public struct UserAPIModel {
                 blogURL: String,
                 blogTitle: String,
                 scrapFeedUUIDs: [String],
+                reportFeedUUIDs: [String],
                 signupDate: Date,
                 updateDate: Date,
                 isPushOn: Bool
@@ -45,6 +47,7 @@ public struct UserAPIModel {
         self.blogURL = blogURL
         self.blogTitle = blogTitle
         self.scrapFeedUUIDs = scrapFeedUUIDs
+        self.reportFeedUUIDs = reportFeedUUIDs
         self.signupDate = signupDate
         self.updateDate = updateDate
         self.isPushOn = isPushOn
@@ -63,6 +66,7 @@ public extension UserAPIModel {
         self.blogURL = data["blogURL"] as? String ?? ""
         self.blogTitle = data["blogTitle"] as? String ?? ""
         self.scrapFeedUUIDs = data["scrapFeedUUIDs"] as? [String] ?? []
+        self.reportFeedUUIDs = data["reportFeedUUIDs"] as? [String] ?? []
         let timestampSignupDate = data["signupDate"] as? Timestamp ?? Timestamp()
         self.signupDate = timestampSignupDate.dateValue()
         let timestampUpdateDate = data["updateDate"] as? Timestamp ?? Timestamp(date: Date(timeIntervalSince1970: 0))
@@ -81,6 +85,7 @@ public extension UserAPIModel {
             "blogURL": blogURL,
             "blogTitle": blogTitle,
             "scrapFeedUUIDs": scrapFeedUUIDs,
+            "reportFeedUUIDs": reportFeedUUIDs,
             "signupDate": Timestamp(date: signupDate),
             "updateDate": Timestamp(date: updateDate),
             "isPushOn": isPushOn


### PR DESCRIPTION
## 관련 이슈
<!--
이슈 번호 #000 작성  
ex) close #1 
--> 
- 앱스토어 거절로 인한 신고, 차단 기능 추가

## 내용
<!--
로직 설명  
필요시 스크린샷 첨부
--> 
- FeedDetail에 차단, 신고 추가
- 차단
  - 내 피드에서 더 이상 안 보임
  - User reportFeedUUID 배열에 저장
- 신고
  - 차단과 동일
  - 서버에 feedUUID가 기록됨
  -  하루에 한 번 일괄처리
- 스크랩과 차단 피드 확인시 배열 사용 -> 딕셔너리 사용
  - 기존에는 FeedList 를 순회하며 Scrap했는지 확인함. FeedList N개, ScrapFeed M개면 O(NM) 의 시간 복잡도
  - 딕셔너리로 수정해서 관리하면 처음 배열 -> 딕셔너리 바꿀 때 N, 탐색에 N -> O(2N)의 시간 복잡도

### 홈 - 신고

https://user-images.githubusercontent.com/71776532/217442064-ad7dafc2-e9ab-42e9-8ba5-996ad4200b73.mp4

### 홈 - 차단

https://user-images.githubusercontent.com/71776532/217442106-cf19edd6-c9a8-458e-82a3-6a71ec07d926.mp4


### 스크랩페이지 - 신고

https://user-images.githubusercontent.com/71776532/217442129-2e681053-445d-4411-9f56-cf53c8effea4.mp4


## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
- 앱스토어 쉽지 않다!!!!!!
