### PR TITLE
[Feat] skeleton View 지연 실행

### DIFF
--- a/burstcamp/burstcamp/Presentation/Common/View/RecommendCell/RecommendFeedHeader.swift
+++ b/burstcamp/burstcamp/Presentation/Common/View/RecommendCell/RecommendFeedHeader.swift
@@ -29,7 +29,6 @@ final class RecommendFeedHeader: UICollectionReusableView {
     }
 
     private lazy var titleLabel = DefaultMultiLineLabel().then {
-        $0.attributedText  = titleAttributeText
         $0.numberOfLines = 2
     }
 
@@ -50,6 +49,14 @@ final class RecommendFeedHeader: UICollectionReusableView {
     private func configureTitleLabel() {
         titleLabel.snp.makeConstraints {
             $0.edges.equalToSuperview()
+        }
+    }
+}
+
+extension RecommendFeedHeader {
+    func updateTitleLabel() {
+        DispatchQueue.main.async {
+            self.titleLabel.attributedText = self.titleAttributeText
         }
     }
 }

--- a/burstcamp/burstcamp/Presentation/Common/View/RecommendCell/RecommendFeedHeader.swift
+++ b/burstcamp/burstcamp/Presentation/Common/View/RecommendCell/RecommendFeedHeader.swift
@@ -7,6 +7,8 @@
 
 import UIKit
 
+import SkeletonView
+
 final class RecommendFeedHeader: UICollectionReusableView {
 
     private let titleText = "이번 주\n캠퍼들의 PICK"
@@ -35,6 +37,7 @@ final class RecommendFeedHeader: UICollectionReusableView {
     override init(frame: CGRect) {
         super.init(frame: frame)
         configureUI()
+        configureSkeleton()
     }
 
     required init?(coder: NSCoder) {
@@ -50,6 +53,13 @@ final class RecommendFeedHeader: UICollectionReusableView {
         titleLabel.snp.makeConstraints {
             $0.edges.equalToSuperview()
         }
+    }
+
+    private func configureSkeleton() {
+        titleLabel.isSkeletonable = true
+        titleLabel.skeletonTextNumberOfLines = 2
+        titleLabel.linesCornerRadius = Constant.CornerRadius.radius4
+        titleLabel.skeletonTextLineHeight = .fixed(28)
     }
 }
 

--- a/burstcamp/burstcamp/Presentation/Tab/Home/View/HomeView.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/Home/View/HomeView.swift
@@ -221,10 +221,23 @@ final class HomeView: UIView, ContainCollectionView {
             return []
         }
     }
+
+    private func setRecommendFeedCount(_ count: Int) {
+        recommendFeedCount = count
+    }
+
+    private func updateHeader() {
+        if let recommendFeedHeader = collectionView.visibleSupplementaryViews(
+            ofKind: UICollectionView.elementKindSectionHeader
+        ).first as? RecommendFeedHeader {
+            recommendFeedHeader.updateTitleLabel()
+        }
+    }
 }
 
 extension HomeView {
-    func setRecommendFeedCount(_ count: Int) {
-        recommendFeedCount = count
+    func updateRecommendSection(recommendFeedCount: Int) {
+        setRecommendFeedCount(recommendFeedCount)
+        updateHeader()
     }
 }

--- a/burstcamp/burstcamp/Presentation/Tab/Home/View/HomeView.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/Home/View/HomeView.swift
@@ -216,6 +216,7 @@ final class HomeView: UIView, ContainCollectionView {
                 bottom: 0,
                 trailing: horizontalPadding
             )
+
             return [header]
         case .normal:
             return []

--- a/burstcamp/burstcamp/Presentation/Tab/Home/ViewController/HomeViewController.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/Home/ViewController/HomeViewController.swift
@@ -229,7 +229,7 @@ extension HomeViewController {
             return
         }
         // carousel View를 위한 설정 -> 2개씩 복사 해줬으므로 진짜 개수는 3으로 나눠줘야 함
-        homeView.setRecommendFeedCount(homeFeedList.recommendFeed.count / 3)
+        homeView.updateRecommendSection(recommendFeedCount: homeFeedList.recommendFeed.count / 3)
         reloadHomeFeedList(homeFeedList: homeFeedList)
         homeView.endCollectionViewRefreshing()
         isFetching = false

--- a/burstcamp/burstcamp/Presentation/Tab/Home/ViewController/HomeViewController.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/Home/ViewController/HomeViewController.swift
@@ -35,6 +35,7 @@ final class HomeViewController: UIViewController {
 
     private var isFetching: Bool = false
     private var isLastFetch: Bool = false
+    private var isDataLoaded = false
 
     init(viewModel: HomeViewModel) {
         self.viewModel = viewModel
@@ -69,7 +70,11 @@ final class HomeViewController: UIViewController {
 
     private func configureAttributes() {
         homeView.collectionView.isSkeletonable = true
-        homeView.collectionView.showSkeleton(usingColor: .systemGray5)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            if !self.isDataLoaded {
+                self.homeView.collectionView.showSkeleton(usingColor: .systemGray5)
+            }
+        }
     }
 
     private func configureNavigationBar() {
@@ -217,6 +222,7 @@ extension HomeViewController {
     }
 
     private func receiveHomeFeedList(homeFeedList: HomeFeedList?) {
+        isDataLoaded = true
         homeView.hideSkeleton()
         guard let homeFeedList = homeFeedList else {
             showAlert(message: "피드 데이터를 가져오는데 에러가 발생했어요")

--- a/burstcamp/burstcamp/Presentation/Tab/Home/ViewController/HomeViewController.swift
+++ b/burstcamp/burstcamp/Presentation/Tab/Home/ViewController/HomeViewController.swift
@@ -70,11 +70,6 @@ final class HomeViewController: UIViewController {
 
     private func configureAttributes() {
         homeView.collectionView.isSkeletonable = true
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-            if !self.isDataLoaded {
-                self.homeView.collectionView.showSkeleton(usingColor: .systemGray5)
-            }
-        }
     }
 
     private func configureNavigationBar() {
@@ -93,6 +88,15 @@ final class HomeViewController: UIViewController {
 
     private func paginateFeed() {
         paginationPublisher.send(Void())
+    }
+
+    private func showSkeletonView(header: RecommendFeedHeader) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            if !self.isDataLoaded {
+                self.homeView.collectionView.showSkeleton(usingColor: .systemGray5)
+                header.showSkeleton(usingColor: .systemGray5)
+            }
+        }
     }
 }
 
@@ -352,7 +356,8 @@ extension HomeViewController {
             ) as? RecommendFeedHeader else {
                 return UICollectionReusableView()
             }
-
+            header.isSkeletonable = true
+            showSkeletonView(header: header)
             return header
         default:
             return nil


### PR DESCRIPTION
## 관련 이슈
<!--
이슈 번호 #000 작성  
ex) close #1 
--> 

## 내용
<!--
로직 설명  
필요시 스크린샷 첨부
--> 
- 깜빡임 방지를 위해 Skeleton View를 지연 실행합니다.
- 추천 섹션 Header에도 skeleton을 적용했습니다.

| 이전 | 이후 |
|:---:|:---:|
|<img width = 300 src = "https://user-images.githubusercontent.com/71776532/217740334-b0307ffb-b4bf-47dc-b7c2-0375f54d1d3f.gif" />|<img width = 300 src = "https://user-images.githubusercontent.com/71776532/217740343-2cefbd89-d52a-4017-8414-ca44d5a39e68.gif" />|

## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
