### PR TITLE
[Bug] html escape 문자 처리

### DIFF
--- a/Firebase-Functions/functions/service/firestoreManager.js
+++ b/Firebase-Functions/functions/service/firestoreManager.js
@@ -170,6 +170,7 @@ async function updateNewRecommendFeedToDB(newRecommendFeedUUIDList) {
 async function updateFeedDBFromSingleBlog(parsedRSS, writer) {
 	logger.log(writer['nickname'])
 	logger.log(writer['blogURL'])
+	if (parsedRSS.items === undefined) { return }
 	await parsedRSS.items.forEach(async (item) => {
 		const feedUUID = item.link.hashCode()
 		const docRef = feedRef.doc(feedUUID);
@@ -210,7 +211,7 @@ async function createFeedDataIfNeeded(docRef, writer, feedUUID, feed) {
 	docRef.set({
 		// TODO: User db에서 UUID를 찾아 대입해주기
 		feedUUID: feedUUID,
-		title: feed.title,
+		title: unescapeHtml(feed.title),
 		pubDate: Timestamp.fromDate(new Date(feed.pubDate)),
 		regDate: Timestamp.now(),
 		url: feed.link,
@@ -225,6 +226,17 @@ async function createFeedDataIfNeeded(docRef, writer, feedUUID, feed) {
 		writerProfileImageURL: writer['profileImageURL'],
 		writerBlogTitle: writer['blogTitle'],
 	})
+}
+
+function unescapeHtml(text) {
+    const str = text
+    return str
+		.replaceAll('&amp;', '&')
+		.replaceAll('&lt;', '<')
+		.replaceAll('&gt;', '>')
+		.replaceAll('&quot;', '"')
+		.replaceAll('&#039;', "'")
+	return str
 }
 
 /**

--- a/burstcamp/burstcamp/Domain/Model/Feed/Feed.swift
+++ b/burstcamp/burstcamp/Domain/Model/Feed/Feed.swift
@@ -29,7 +29,7 @@ extension Feed {
     ) {
         self.feedUUID = feedAPIModel.feedUUID
         self.writer = FeedWriter(feedAPIModel: feedAPIModel)
-        self.title = feedAPIModel.title
+        self.title = feedAPIModel.title.changeEscapeString()
         self.pubDate = feedAPIModel.pubDate
         self.url = feedAPIModel.url
         self.thumbnailURL = feedAPIModel.thumbnailURL

--- a/burstcamp/burstcamp/Util/Extension/Type/String+.swift
+++ b/burstcamp/burstcamp/Util/Extension/Type/String+.swift
@@ -61,3 +61,22 @@ extension String {
         return self.range(of: regex, options: .regularExpression) != nil
     }
 }
+
+// MARK: - html escape 문자 변경
+
+extension String {
+    func changeEscapeString() -> String {
+        guard let data = self.data(using: .utf8) else { return self }
+        let options: [NSAttributedString.DocumentReadingOptionKey: Any] = [
+            .documentType: NSAttributedString.DocumentType.html,
+            .characterEncoding: String.Encoding.utf8.rawValue
+        ]
+        guard let attributedString = try? NSAttributedString(
+            data: data,
+            options: options,
+            documentAttributes: nil
+        )
+        else { return self }
+        return attributedString.string
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- close #359 

## 내용
- js 피드 저장시 제목 escape 문자 처리 -> 전부 처리는 아니고 자주 사용하는 일부 문자 처리했습니다.
(원래 unescape() 함수를 사용하면 됐는데 deprecated 됐네요,,)

- 이미 저장된 피드를 위해 Swift로 escape 처리를 한번 더 해주는 것으로 변경했어요. 
